### PR TITLE
Feature/issue 144 cache profile and convos

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
 
     id 'kotlin-android'
     id "kotlin-kapt"
+    id 'com.google.devtools.ksp'
     id "dagger.hilt.android.plugin"
 }
 
@@ -145,6 +146,15 @@ dependencies {
     implementation "io.coil-kt:coil-compose:2.3.0"
     implementation 'com.google.accompanist:accompanist-pager:0.23.0'
 
+    // Local DB (cache)
+    implementation "androidx.room:room-runtime:$room_version"
+    annotationProcessor "androidx.room:room-compiler:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-ktx:$room_version"
+    testImplementation "androidx.room:room-testing:$room_version"
+
+    // JSON
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0"
 }
 
 tasks.withType(Test) {

--- a/app/src/androidTest/java/com/studhub/app/data/NetworkStatusImplTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/NetworkStatusImplTest.kt
@@ -1,0 +1,14 @@
+package com.studhub.app.data
+
+import com.studhub.app.data.network.NetworkStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class NetworkStatusImplTest : NetworkStatus {
+    override val isConnected: Boolean
+        get() = true
+
+    override fun connectivityStatus(): Flow<Boolean> {
+        return flowOf(true)
+    }
+}

--- a/app/src/androidTest/java/com/studhub/app/data/local/dao/ConversationDaoTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/local/dao/ConversationDaoTest.kt
@@ -1,0 +1,130 @@
+package com.studhub.app.data.local.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.local.database.LocalAppDatabase
+import com.studhub.app.domain.model.Conversation
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+class ConversationDaoTest {
+    private lateinit var localDb: LocalAppDatabase
+    private lateinit var cache: LocalDataSource
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        localDb = Room.inMemoryDatabaseBuilder(
+            context, LocalAppDatabase::class.java
+        ).build()
+        cache = LocalDataSource(localDb)
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        localDb.close()
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun setAndGetMessage() {
+        val conversationId = Random.nextLong().toString()
+        val conversation1 = Conversation(id = conversationId, user1Name = "Bobby")
+        val conversation2 = Conversation(id = Random.nextLong().toString(), user1Name = "Michelle")
+
+        runBlocking {
+            cache.saveConversation(conversation1)
+            cache.saveConversation(conversation2)
+        }
+
+        var byId: Conversation?
+
+        runBlocking { byId = cache.getConversation(conversationId) }
+
+        assertEquals(conversation1.user1Name, byId!!.user1Name)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun getConversationsReturnsOnlyGivenUserConversations() {
+        val userId = Random.nextLong().toString()
+        val conversationId1 = Random.nextLong().toString()
+        val conversationId2 = Random.nextLong().toString()
+        val conversation1 = Conversation(
+            id = conversationId1,
+            user1Id = userId,
+            user1Name = "Bobby",
+            user2Name = "Michelle"
+        )
+        val conversation2 = Conversation(
+            id = conversationId2,
+            user2Id = userId,
+            user1Name = "Jean-Marc",
+            user2Name = "Bobby"
+        )
+        val conversation3 = Conversation(
+            id = Random.nextLong().toString(),
+            user1Id = "xxxx",
+            user1Name = "Jean-Marc",
+            user2Name = "Robert"
+        )
+        val conversation4 = Conversation(
+            id = Random.nextLong().toString(),
+            user2Id = "yyyy",
+            user1Name = "Jean-Marc",
+            user2Name = "Michelle"
+        )
+
+        runBlocking {
+            cache.saveConversation(conversation1)
+            cache.saveConversation(conversation2)
+            cache.saveConversation(conversation3)
+            cache.saveConversation(conversation4)
+        }
+
+        var convos: List<Conversation>
+
+        runBlocking { convos = cache.getConversations(userId) }
+
+        assertEquals("Only 2 conversations are Bobby's", 2, convos.size)
+
+        val conversation1Singleton = convos.filter { it.user1Id == userId }
+        val conversation2Singleton = convos.filter { it.user2Id == userId }
+
+        assertEquals(
+            "There is 1 conversation for which user is user1",
+            1,
+            conversation1Singleton.size
+        )
+
+        assertEquals(
+            "Conversation 1 is correctly retrieved",
+            conversationId1,
+            conversation1Singleton.first().id
+        )
+
+        assertEquals(
+            "There is 1 conversation for which user is user2",
+            1,
+            conversation2Singleton.size
+        )
+
+        assertEquals(
+            "Conversation 2 is correctly retrieved",
+            conversationId2,
+            conversation2Singleton.first().id
+        )
+
+    }
+}

--- a/app/src/androidTest/java/com/studhub/app/data/local/dao/MessageDaoTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/local/dao/MessageDaoTest.kt
@@ -1,0 +1,90 @@
+package com.studhub.app.data.local.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.local.database.LocalAppDatabase
+import com.studhub.app.domain.model.Message
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.util.*
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+class MessageDaoTest {
+    private lateinit var localDb: LocalAppDatabase
+    private lateinit var cache: LocalDataSource
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        localDb = Room.inMemoryDatabaseBuilder(
+            context, LocalAppDatabase::class.java
+        ).build()
+        cache = LocalDataSource(localDb)
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        localDb.close()
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun setAndGetMessages() {
+        val conversationId = Random.nextLong().toString()
+        val message1Id = Random.nextLong().toString()
+        val message2Id = Random.nextLong().toString()
+        val message1 = Message(
+            id = message1Id,
+            conversationId = conversationId,
+            senderId = "Bobby",
+            createdAt = Date(1000)
+        )
+        val message2 =
+            Message(
+                id = message2Id,
+                conversationId = conversationId,
+                senderId = "Michelle",
+                createdAt = Date(99999)
+            )
+        val message3 = Message(
+            id = Random.nextLong().toString(),
+            conversationId = Random.nextLong().toString()
+        )
+
+
+        // store the latest message between message1 and message2
+        // this is to test that they are retrieved from the oldest to the latest and not in insertion order
+        runBlocking { cache.saveMessage(message2) }
+
+        runBlocking {
+            cache.saveMessage(message1)
+            cache.saveMessage(message3)
+        }
+
+        var messages: List<Message>
+
+        runBlocking { messages = cache.getMessages(conversationId) }
+
+        assertEquals("The given conversation should only have 2 messages", 2, messages.size)
+        assertEquals(
+            "First message should be the earlier one (message1)",
+            message1.id,
+            messages.first().id
+        )
+        assertEquals(
+            "Second and last message should be the latest message (message2)",
+            message2.id,
+            messages.last().id
+        )
+    }
+}

--- a/app/src/androidTest/java/com/studhub/app/data/local/dao/UserDaoTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/local/dao/UserDaoTest.kt
@@ -1,0 +1,86 @@
+package com.studhub.app.data.local.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.local.database.LocalAppDatabase
+import com.studhub.app.domain.model.User
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+class UserDaoTest {
+    private lateinit var localDb: LocalAppDatabase
+    private lateinit var cache: LocalDataSource
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        localDb = Room.inMemoryDatabaseBuilder(
+            context, LocalAppDatabase::class.java
+        ).build()
+        cache = LocalDataSource(localDb)
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        localDb.close()
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun setAndGetUser() {
+        val userId = Random.nextLong().toString()
+        val user1 = User(id = userId, userName = "Bobby")
+        val user2 = User(id = Random.nextLong().toString(), userName = "Michelle")
+
+        runBlocking {
+            cache.saveUser(user1)
+            cache.saveUser(user2)
+        }
+
+        var byId: User?
+
+        runBlocking { byId = cache.getUser(userId) }
+
+        assertEquals(user1.userName, byId!!.userName)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun setAndGetAndDeleteAndGetUser() {
+        val userId = Random.nextLong().toString()
+        val user1 = User(id = userId, userName = "Bobby")
+        val user2 = User(id = Random.nextLong().toString(), userName = "Michelle")
+
+        // store 2 users
+        runBlocking {
+            cache.saveUser(user1)
+            cache.saveUser(user2)
+        }
+
+        var byId: User?
+
+        runBlocking { byId = cache.getUser(userId) }
+
+        assertEquals(user1.userName, byId!!.userName)
+
+        // delete 1 user
+        runBlocking { cache.removeUser(userId) }
+
+        // try fetching the deleted user
+        runBlocking { byId = cache.getUser(userId) }
+
+        assertNull(byId)
+    }
+}

--- a/app/src/androidTest/java/com/studhub/app/data/local/dao/UserFavListingsDaoTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/local/dao/UserFavListingsDaoTest.kt
@@ -1,0 +1,137 @@
+package com.studhub.app.data.local.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.local.database.LocalAppDatabase
+import com.studhub.app.domain.model.Listing
+import com.studhub.app.domain.model.Message
+import com.studhub.app.domain.model.User
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.util.*
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+class UserFavListingsDaoTest {
+    private lateinit var localDb: LocalAppDatabase
+    private lateinit var cache: LocalDataSource
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        localDb = Room.inMemoryDatabaseBuilder(
+            context, LocalAppDatabase::class.java
+        ).build()
+        cache = LocalDataSource(localDb)
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        localDb.close()
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addAndRemoveFavoriteListing() {
+        val userId = Random.nextLong().toString()
+        val listingId = Random.nextLong().toString()
+        val listing = Listing(
+            id = listingId,
+            sellerId = userId,
+            createdAt = Date(1000)
+        )
+
+        // store listing and add it to user's favorite
+        runBlocking {
+            cache.saveFavoriteListing(userId, listing)
+        }
+
+        var favorites: List<Listing>
+
+        runBlocking { favorites = cache.getFavListings(userId) }
+
+        assertEquals("User has 1 favorite", 1, favorites.size)
+
+        // remove user's fav listing
+        runBlocking { cache.removeFavoriteListing(userId, listing.id) }
+
+        runBlocking { favorites = cache.getFavListings(userId) }
+
+        assertEquals("User has no favorites", 0, favorites.size)
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun onlyGivenUserFavListingsAreRetrieved() {
+        val userId = Random.nextLong().toString()
+        val michelle = User(id = "Michelle")
+        val listing1Id = Random.nextLong().toString()
+        val listing2Id = Random.nextLong().toString()
+        val listing1 = Listing(
+            id = listing1Id,
+            sellerId = userId,
+            createdAt = Date(1000)
+        )
+        val listing2 = Listing(
+            id = listing2Id,
+            sellerId = userId,
+            createdAt = Date(1000)
+        )
+        val listing3 = Listing(
+            id = Random.nextLong().toString(),
+            sellerId = "Michelle",
+            createdAt = Date(1000)
+        )
+
+        // store listings and
+        // - add listings 1 and 2 to user's favorite
+        // - add listing 3 to Michelle's favorite
+        runBlocking {
+            cache.saveFavoriteListing(userId, listing1)
+            cache.saveFavoriteListing(userId, listing2)
+            cache.saveFavoriteListing(michelle.id, listing3)
+        }
+
+        var favListings: List<Listing>
+
+        runBlocking { favListings = cache.getFavListings(userId) }
+
+        assertEquals("The given user should only have 2 fav listings", 2, favListings.size)
+
+        val listing1Singleton = favListings.filter { it.id == listing1Id }
+        val listing2Singleton = favListings.filter { it.id == listing2Id }
+
+        assertEquals(
+            "There is 1 fav listing which is listing1",
+            1,
+            listing1Singleton.size
+        )
+
+        assertEquals(
+            "There is 1 fav listing which is listing2",
+            1,
+            listing2Singleton.size
+        )
+
+        assertEquals(
+            "Listing1 is correctly retrieved",
+            listing1Id,
+            listing1Singleton.first().id
+        )
+
+        assertEquals(
+            "Listing2 is correctly retrieved",
+            listing2Id,
+            listing2Singleton.first().id
+        )
+    }
+}

--- a/app/src/androidTest/java/com/studhub/app/data/repository/MockUserRepositoryImpl.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/repository/MockUserRepositoryImpl.kt
@@ -68,14 +68,14 @@ class MockUserRepositoryImpl : UserRepository {
 
     override suspend fun addFavoriteListing(
         userId: String,
-        favListingId: String
+        favListing: Listing
     ): Flow<ApiResponse<User>> {
         return flow {
             emit(ApiResponse.Loading)
             if (userDB.containsKey(userId)) {
                 val user = userDB.getValue(userId)
                 val updatedFavoriteListings =
-                    user.favoriteListings.toMutableMap().apply { put(favListingId, true) }
+                    user.favoriteListings.toMutableMap().apply { put(favListing.id, true) }
                 val updatedUser = user.copy(favoriteListings = updatedFavoriteListings)
                 userDB[userId] = updatedUser
                 emit(ApiResponse.Success(updatedUser))
@@ -87,14 +87,14 @@ class MockUserRepositoryImpl : UserRepository {
 
     override suspend fun removeFavoriteListing(
         userId: String,
-        favListingId: String
+        favListing: Listing
     ): Flow<ApiResponse<User>> {
         return flow {
             emit(ApiResponse.Loading)
             if (userDB.containsKey(userId)) {
                 val user = userDB[userId]!!
                 val updatedFavoriteListings =
-                    user.favoriteListings.toMutableMap().apply { remove(favListingId) }
+                    user.favoriteListings.toMutableMap().apply { remove(favListing.id) }
                 val updatedUser = user.copy(favoriteListings = updatedFavoriteListings)
                 userDB[userId] = updatedUser
 

--- a/app/src/androidTest/java/com/studhub/app/data/repository/UserRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/repository/UserRepositoryImplTest.kt
@@ -1,7 +1,10 @@
 package com.studhub.app.data.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.database.FirebaseDatabase
 import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.User
 import com.studhub.app.domain.repository.UserRepository
@@ -30,6 +33,14 @@ class UserRepositoryImplTest {
     @Inject
     lateinit var getUser: GetUser
 
+    @Inject
+    lateinit var remoteDb: FirebaseDatabase
+
+    @Inject
+    lateinit var localDb: LocalDataSource
+
+    @Inject
+    lateinit var networkStatus: NetworkStatus
 
 
     @Before
@@ -39,7 +50,7 @@ class UserRepositoryImplTest {
 
     @Test
     fun setAndGetSameUser() {
-        val userRepo = UserRepositoryImpl() // real repo
+        val userRepo = UserRepositoryImpl(remoteDb, localDb, networkStatus) // real repo
         val getUser = GetUser(userRepo)
         lateinit var user: User
 
@@ -77,7 +88,7 @@ class UserRepositoryImplTest {
 
     @Test
     fun addAndGetFavoriteListing() {
-        val userRepo = UserRepositoryImpl() // real repo
+        val userRepo = UserRepositoryImpl(remoteDb, localDb, networkStatus) // real repo
         val authRepo = MockAuthRepositoryImpl() // fake repo
         val addFavoriteListing = AddFavoriteListing(userRepo, authRepo)
         val getFavoriteListings = GetFavoriteListings(userRepo, authRepo)
@@ -87,7 +98,7 @@ class UserRepositoryImplTest {
         )
 
         runBlocking {
-            addFavoriteListing(product.id).collect() {
+            addFavoriteListing(product).collect() {
                 when (it) {
                     is ApiResponse.Failure -> fail(it.message)
                     ApiResponse.Loading -> {}
@@ -109,7 +120,7 @@ class UserRepositoryImplTest {
 
     @Test
     fun addAndRemoveFavoriteListing() {
-        val userRepo = UserRepositoryImpl() // real repo
+        val userRepo = UserRepositoryImpl(remoteDb, localDb, networkStatus) // real repo
         val authRepo = MockAuthRepositoryImpl() // fake repo
         val addFavoriteListing = AddFavoriteListing(userRepo, authRepo)
         val removeFavoriteListing = RemoveFavoriteListing(userRepo, authRepo)
@@ -119,7 +130,7 @@ class UserRepositoryImplTest {
         )
 
         runBlocking {
-            addFavoriteListing(product.id).collect() {
+            addFavoriteListing(product).collect {
                 when (it) {
                     is ApiResponse.Failure -> fail(it.message)
                     ApiResponse.Loading -> {}
@@ -129,7 +140,7 @@ class UserRepositoryImplTest {
         }
 
         runBlocking {
-            removeFavoriteListing(product.id).collect {
+            removeFavoriteListing(product).collect {
                 when (it) {
                     is ApiResponse.Failure -> fail(it.message)
                     is ApiResponse.Loading -> {}
@@ -141,7 +152,7 @@ class UserRepositoryImplTest {
 
     @Test
     fun addAndRemoveBlockedUser() {
-        val userRepo = UserRepositoryImpl() // real repo
+        val userRepo = UserRepositoryImpl(remoteDb, localDb, networkStatus) // real repo
         val authRepo = MockAuthRepositoryImpl() // fake repo
         val addBlockedUser = AddBlockedUser(userRepo, authRepo)
         val removeBlockedUser = UnblockUser(userRepo, authRepo)

--- a/app/src/androidTest/java/com/studhub/app/di/AppTestModule.kt
+++ b/app/src/androidTest/java/com/studhub/app/di/AppTestModule.kt
@@ -3,6 +3,8 @@ package com.studhub.app.di
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
+import com.studhub.app.data.NetworkStatusImplTest
+import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.data.repository.*
 import com.studhub.app.domain.repository.*
 import com.studhub.app.domain.usecase.category.GetCategories
@@ -33,6 +35,9 @@ class AppTestModule {
 
     @Provides
     fun provideFirebaseDatabase() = Firebase.database
+
+    @Provides
+    fun provideNetworkStatus(): NetworkStatus = NetworkStatusImplTest()
 
     @Singleton
     @Provides

--- a/app/src/androidTest/java/com/studhub/app/di/AppTestModule.kt
+++ b/app/src/androidTest/java/com/studhub/app/di/AppTestModule.kt
@@ -1,9 +1,14 @@
 package com.studhub.app.di
 
+import android.content.Context
+import androidx.room.Room
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import com.studhub.app.data.NetworkStatusImplTest
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.local.database.LocalAppDatabase
 import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.data.repository.*
 import com.studhub.app.domain.repository.*
@@ -20,6 +25,7 @@ import com.studhub.app.domain.usecase.user.SignOut
 import com.studhub.app.domain.usecase.user.UpdateCurrentUserInfo
 import dagger.Module
 import dagger.Provides
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import javax.inject.Singleton
@@ -37,6 +43,17 @@ class AppTestModule {
     fun provideFirebaseDatabase() = Firebase.database
 
     @Provides
+    @Singleton
+    fun provideLocalDatabase(@ApplicationContext context: Context): LocalAppDatabase =
+        Room.inMemoryDatabaseBuilder(
+            context,
+            LocalAppDatabase::class.java,
+        ).build()
+
+    @Provides
+    fun provideLocalDatasource(localDatabase: LocalAppDatabase) = LocalDataSource(localDatabase)
+
+    @Provides
     fun provideNetworkStatus(): NetworkStatus = NetworkStatusImplTest()
 
     @Singleton
@@ -49,7 +66,11 @@ class AppTestModule {
 
     @Singleton
     @Provides
-    fun provideListingRepository(): ListingRepository = ListingRepositoryImpl()
+    fun provideListingRepository(
+        remoteDb: FirebaseDatabase,
+        localDb: LocalDataSource,
+        networkStatus: NetworkStatus
+    ): ListingRepository = ListingRepositoryImpl(remoteDb, localDb, networkStatus)
 
     @Singleton
     @Provides
@@ -57,11 +78,19 @@ class AppTestModule {
 
     @Singleton
     @Provides
-    fun provideConversationRepository(): ConversationRepository = ConversationRepositoryImpl()
+    fun provideConversationRepository(
+        remoteDb: FirebaseDatabase,
+        localDb: LocalDataSource,
+        networkStatus: NetworkStatus
+    ): ConversationRepository = ConversationRepositoryImpl(remoteDb, localDb, networkStatus)
 
     @Singleton
     @Provides
-    fun provideMessageRepository(): MessageRepository = MessageRepositoryImpl()
+    fun provideMessageRepository(
+        remoteDb: FirebaseDatabase,
+        localDb: LocalDataSource,
+        networkStatus: NetworkStatus
+    ): MessageRepository = MessageRepositoryImpl(remoteDb, localDb, networkStatus)
 
     @Singleton
     @Provides

--- a/app/src/androidTest/java/com/studhub/app/domain/usecase/UserUseCaseTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/domain/usecase/UserUseCaseTest.kt
@@ -109,14 +109,14 @@ class UserUseCaseTest {
 
         override suspend fun addFavoriteListing(
             userId: String,
-            favListingId: String
+            favListing: Listing
         ): Flow<ApiResponse<User>> {
             return flow {
                 emit(ApiResponse.Loading)
                 if (userDB.containsKey(userId)) {
                     val user = userDB.getValue(userId)
                     val updatedFavoriteListings =
-                        user.favoriteListings.toMutableMap().apply { put(favListingId, true) }
+                        user.favoriteListings.toMutableMap().apply { put(favListing.id, true) }
                     val updatedUser = user.copy(favoriteListings = updatedFavoriteListings)
                     userDB[userId] = updatedUser
                     emit(ApiResponse.Success(updatedUser))
@@ -128,14 +128,14 @@ class UserUseCaseTest {
 
         override suspend fun removeFavoriteListing(
             userId: String,
-            favListingId: String
+            favListing: Listing
         ): Flow<ApiResponse<User>> {
             return flow {
                 emit(ApiResponse.Loading)
                 if (userDB.containsKey(userId)) {
                     val user = userDB[userId]!!
                     val updatedFavoriteListings =
-                        user.favoriteListings.toMutableMap().apply { remove(favListingId) }
+                        user.favoriteListings.toMutableMap().apply { remove(favListing.id) }
                     val updatedUser = user.copy(favoriteListings = updatedFavoriteListings)
                     userDB[userId] = updatedUser
 
@@ -298,7 +298,7 @@ class UserUseCaseTest {
         val listingId = Random.nextLong().toString()
         userDB[userId] = User(id = userId, userName = "Test User", favoriteListings = emptyMap())
 
-        addFavoriteListing(listingId).collect { response ->
+        addFavoriteListing(Listing(id = listingId)).collect { response ->
             when (response) {
                 is ApiResponse.Success -> {
                     val user = response.data
@@ -344,7 +344,7 @@ class UserUseCaseTest {
             favoriteListings = mapOf(listingId1 to true, listingId2 to true)
         )
 
-        removeFavoriteListing(listingId1).collect { response ->
+        removeFavoriteListing(Listing(id = listingId1)).collect { response ->
             when (response) {
                 is ApiResponse.Success -> {
                     val result = response.data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
 
     <application

--- a/app/src/main/java/com/studhub/app/MainActivity.kt
+++ b/app/src/main/java/com/studhub/app/MainActivity.kt
@@ -12,19 +12,26 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.studhub.app.core.Globals
+import com.studhub.app.core.utils.Utils
+import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.presentation.auth.AuthViewModel
 import com.studhub.app.presentation.nav.NavBar
 import com.studhub.app.presentation.ui.theme.StudHubTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private lateinit var navController: NavHostController
 
     private val viewModel by viewModels<AuthViewModel>()
+
+    @Inject
+    lateinit var networkManager: NetworkStatus
 
     @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
     @OptIn(ExperimentalMaterial3Api::class)
@@ -50,6 +57,7 @@ class MainActivity : AppCompatActivity() {
                             AppNavigation(navController = navController)
                         }
                         AuthState()
+                        ConnectivityState()
                     })
             }
         }
@@ -72,12 +80,13 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun checkAuthState() {
-        if (viewModel.isUserAuthenticated) {
-            handleLoginComplete()
+    @Composable
+    private fun ConnectivityState() {
+        val networkStatus = networkManager.connectivityStatus().collectAsState(initial = true).value
+
+        if (!networkStatus) {
+            Utils.displayMessage(applicationContext, stringResource(R.string.error_network_off))
         }
     }
-
-    private fun handleLoginComplete() = navController.navigate("Home")
 
 }

--- a/app/src/main/java/com/studhub/app/NavigationComponent.kt
+++ b/app/src/main/java/com/studhub/app/NavigationComponent.kt
@@ -23,7 +23,6 @@ import com.studhub.app.presentation.profile.EditProfileScreen
 import com.studhub.app.presentation.profile.ProfileFavoritesScreen
 import com.studhub.app.presentation.profile.ProfileScreen
 import com.studhub.app.presentation.ratings.UserRatingScreen
-import com.studhub.app.presentation.ratings.UserRatingViewModel
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Preview
@@ -109,6 +108,17 @@ fun AppNavigation(
             ConversationScreen(navigateToDiscussion = { conversationId -> navController.navigate("Conversations/$conversationId") })
         }
 
+        composable("Conversations/{id}") {
+            Globals.showBottomBar = false
+            val id = it.arguments?.getString("id")
+            if (id == null) {
+                navController.navigate("Conversations")
+                return@composable
+            }
+
+            ChatScreen(conversationId = id, navigateBack = { navController.popBackStack() })
+        }
+
         composable("DetailedListing/{id}") { backStackEntry ->
             Globals.showBottomBar = false
             val id = backStackEntry.arguments?.getString("id")
@@ -119,7 +129,9 @@ fun AppNavigation(
 
             DetailedListingScreen(
                 id = id,
-                navigateToConversation = { conversationId -> navController.navigate("Conversations/$conversationId") }, navController = navController)
+                navigateToConversation = { conversationId -> navController.navigate("Conversations/$conversationId") },
+                navigateToRateUser = { userId -> navController.navigate("RatingScreen/$userId") }
+            )
         }
 
 //        composable("RatingScreen") {

--- a/app/src/main/java/com/studhub/app/core/utils/ApiResponse.kt
+++ b/app/src/main/java/com/studhub/app/core/utils/ApiResponse.kt
@@ -8,4 +8,8 @@ sealed class ApiResponse<out T> {
     data class Success<T>(val data: T): ApiResponse<T>()
     data class Failure(val message: String): ApiResponse<Nothing>()
     object Loading: ApiResponse<Nothing>()
+
+    companion object {
+        val NO_INTERNET_CONNECTION = Failure("No internet connection")
+    }
 }

--- a/app/src/main/java/com/studhub/app/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/studhub/app/data/local/LocalDataSource.kt
@@ -1,0 +1,53 @@
+package com.studhub.app.data.local
+
+import com.studhub.app.data.local.database.LocalAppDatabase
+import com.studhub.app.domain.model.Conversation
+import com.studhub.app.domain.model.Listing
+import com.studhub.app.domain.model.Message
+import com.studhub.app.domain.model.User
+import javax.inject.Inject
+
+class LocalDataSource @Inject constructor(
+    private val localDatabase: LocalAppDatabase
+) {
+    private val userDao = localDatabase.userDao()
+    private val conversationDao = localDatabase.conversationDao()
+    private val messageDao = localDatabase.messageDao()
+    private val listingDao = localDatabase.listingDao()
+
+    suspend fun getUser(id: String): User? {
+        return userDao.getUser(id)
+    }
+
+    suspend fun removeUser(id: String) {
+        return userDao.deleteUser(id)
+    }
+
+    suspend fun saveUser(user: User) {
+        userDao.insertUser(user)
+    }
+
+    suspend fun getConversations(userId: String): List<Conversation> {
+        return conversationDao.getConversations(userId)
+    }
+
+    suspend fun saveConversation(conversation: Conversation) {
+        conversationDao.insertConversation(conversation)
+    }
+
+    suspend fun getMessages(conversationId: String): List<Message> {
+        return messageDao.getMessages(conversationId)
+    }
+
+    suspend fun saveMessage(message: Message) {
+        messageDao.insertMessage(message)
+    }
+
+    suspend fun getListings(): List<Listing> {
+        return listingDao.getListings()
+    }
+
+    suspend fun saveListing(listing: Listing) {
+        listingDao.insertListing(listing)
+    }
+}

--- a/app/src/main/java/com/studhub/app/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/studhub/app/data/local/LocalDataSource.kt
@@ -49,18 +49,6 @@ class LocalDataSource @Inject constructor(
         messageDao.insertMessage(message)
     }
 
-    suspend fun getListings(): List<Listing> {
-        return listingDao.getListings()
-    }
-
-    suspend fun saveListing(listing: Listing) {
-        listingDao.insertListing(listing)
-    }
-
-    suspend fun removeListing(id: String) {
-        return listingDao.deleteListing(id)
-    }
-
     suspend fun getFavListings(userId: String): List<Listing> {
         return userFavListingsDao.getUserFavorites(userId)
     }
@@ -73,5 +61,13 @@ class LocalDataSource @Inject constructor(
     suspend fun removeFavoriteListing(userId: String, listingId: String) {
         removeListing(listingId)
         userFavListingsDao.deleteFavoriteListing(userId, listingId)
+    }
+
+    private suspend fun saveListing(listing: Listing) {
+        listingDao.insertListing(listing)
+    }
+
+    private suspend fun removeListing(id: String) {
+        return listingDao.deleteListing(id)
     }
 }

--- a/app/src/main/java/com/studhub/app/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/studhub/app/data/local/LocalDataSource.kt
@@ -1,6 +1,7 @@
 package com.studhub.app.data.local
 
 import com.studhub.app.data.local.database.LocalAppDatabase
+import com.studhub.app.data.local.entity.UserFavoriteListings
 import com.studhub.app.domain.model.Conversation
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.Message
@@ -14,6 +15,7 @@ class LocalDataSource @Inject constructor(
     private val conversationDao = localDatabase.conversationDao()
     private val messageDao = localDatabase.messageDao()
     private val listingDao = localDatabase.listingDao()
+    private val userFavListingsDao = localDatabase.userFavListingsDao()
 
     suspend fun getUser(id: String): User? {
         return userDao.getUser(id)
@@ -29,6 +31,10 @@ class LocalDataSource @Inject constructor(
 
     suspend fun getConversations(userId: String): List<Conversation> {
         return conversationDao.getConversations(userId)
+    }
+
+    suspend fun getConversation(conversationId: String): Conversation {
+        return conversationDao.getConversation(conversationId)
     }
 
     suspend fun saveConversation(conversation: Conversation) {
@@ -49,5 +55,23 @@ class LocalDataSource @Inject constructor(
 
     suspend fun saveListing(listing: Listing) {
         listingDao.insertListing(listing)
+    }
+
+    suspend fun removeListing(id: String) {
+        return listingDao.deleteListing(id)
+    }
+
+    suspend fun getFavListings(userId: String): List<Listing> {
+        return userFavListingsDao.getUserFavorites(userId)
+    }
+
+    suspend fun saveFavoriteListing(userId: String, listing: Listing) {
+        saveListing(listing)
+        userFavListingsDao.insertFavoriteListing(UserFavoriteListings(userId, listing.id))
+    }
+
+    suspend fun removeFavoriteListing(userId: String, listingId: String) {
+        removeListing(listingId)
+        userFavListingsDao.deleteFavoriteListing(userId, listingId)
     }
 }

--- a/app/src/main/java/com/studhub/app/data/local/dao/ConversationDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/ConversationDao.kt
@@ -1,0 +1,14 @@
+package com.studhub.app.data.local.dao
+
+import androidx.room.*
+import com.studhub.app.domain.model.Conversation
+
+@Dao
+interface ConversationDao {
+    @Transaction
+    @Query("SELECT * FROM conversation WHERE user1Id = :userId OR user2Id = :userId")
+    suspend fun getConversations(userId: String): List<Conversation>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertConversation(conversation: Conversation)
+}

--- a/app/src/main/java/com/studhub/app/data/local/dao/ConversationDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/ConversationDao.kt
@@ -6,8 +6,11 @@ import com.studhub.app.domain.model.Conversation
 @Dao
 interface ConversationDao {
     @Transaction
-    @Query("SELECT * FROM conversation WHERE user1Id = :userId OR user2Id = :userId")
+    @Query("SELECT * FROM conversation WHERE user1Id = :userId OR user2Id = :userId ORDER BY updatedAt DESC")
     suspend fun getConversations(userId: String): List<Conversation>
+
+    @Query("SELECT * FROM conversation WHERE conversation_id = :conversationId")
+    suspend fun getConversation(conversationId: String): Conversation
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertConversation(conversation: Conversation)

--- a/app/src/main/java/com/studhub/app/data/local/dao/ListingDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/ListingDao.kt
@@ -1,0 +1,14 @@
+package com.studhub.app.data.local.dao
+
+import androidx.room.*
+import com.studhub.app.domain.model.Listing
+
+@Dao
+interface ListingDao {
+    @Transaction
+    @Query("SELECT * FROM listing")
+    suspend fun getListings(): List<Listing>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertListing(listing: Listing)
+}

--- a/app/src/main/java/com/studhub/app/data/local/dao/ListingDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/ListingDao.kt
@@ -5,10 +5,6 @@ import com.studhub.app.domain.model.Listing
 
 @Dao
 interface ListingDao {
-    @Transaction
-    @Query("SELECT * FROM listing ORDER BY createdAt DESC")
-    suspend fun getListings(): List<Listing>
-
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertListing(listing: Listing)
 

--- a/app/src/main/java/com/studhub/app/data/local/dao/ListingDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/ListingDao.kt
@@ -6,9 +6,12 @@ import com.studhub.app.domain.model.Listing
 @Dao
 interface ListingDao {
     @Transaction
-    @Query("SELECT * FROM listing")
+    @Query("SELECT * FROM listing ORDER BY createdAt DESC")
     suspend fun getListings(): List<Listing>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertListing(listing: Listing)
+
+    @Query("DELETE FROM listing WHERE listing_id = :id")
+    suspend fun deleteListing(id: String)
 }

--- a/app/src/main/java/com/studhub/app/data/local/dao/MessageDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/MessageDao.kt
@@ -1,0 +1,14 @@
+package com.studhub.app.data.local.dao
+
+import androidx.room.*
+import com.studhub.app.domain.model.Message
+
+@Dao
+interface MessageDao {
+    @Transaction
+    @Query("SELECT * FROM message WHERE conversationId = :conversationId")
+    suspend fun getMessages(conversationId: String): List<Message>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMessage(message: Message)
+}

--- a/app/src/main/java/com/studhub/app/data/local/dao/MessageDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/MessageDao.kt
@@ -6,7 +6,7 @@ import com.studhub.app.domain.model.Message
 @Dao
 interface MessageDao {
     @Transaction
-    @Query("SELECT * FROM message WHERE conversationId = :conversationId")
+    @Query("SELECT * FROM message WHERE conversationId = :conversationId ORDER BY createdAt ASC")
     suspend fun getMessages(conversationId: String): List<Message>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/studhub/app/data/local/dao/UserDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/UserDao.kt
@@ -8,10 +8,10 @@ import com.studhub.app.domain.model.User
 
 @Dao
 interface UserDao {
-    @Query("SELECT * FROM user WHERE id = :id")
+    @Query("SELECT * FROM user WHERE user_id = :id")
     suspend fun getUser(id: String): User?
 
-    @Query("DELETE FROM user WHERE id = :id")
+    @Query("DELETE FROM user WHERE user_id = :id")
     suspend fun deleteUser(id: String)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/studhub/app/data/local/dao/UserDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/UserDao.kt
@@ -1,0 +1,19 @@
+package com.studhub.app.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.studhub.app.domain.model.User
+
+@Dao
+interface UserDao {
+    @Query("SELECT * FROM user WHERE id = :id")
+    suspend fun getUser(id: String): User?
+
+    @Query("DELETE FROM user WHERE id = :id")
+    suspend fun deleteUser(id: String)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertUser(user: User)
+}

--- a/app/src/main/java/com/studhub/app/data/local/dao/UserFavListingsDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/UserFavListingsDao.kt
@@ -1,0 +1,22 @@
+package com.studhub.app.data.local.dao
+
+import androidx.room.*
+import com.studhub.app.data.local.entity.UserFavoriteListings
+import com.studhub.app.domain.model.Listing
+
+@Dao
+interface UserFavListingsDao {
+    @Transaction
+    @Query(
+        "SELECT * FROM listing AS l " +
+                "INNER JOIN user_fav_listings AS f ON l.listing_id = f.listing_id " +
+                "WHERE f.user_id = :userId"
+    )
+    suspend fun getUserFavorites(userId: String): List<Listing>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertFavoriteListing(userFavoriteListings: UserFavoriteListings)
+
+    @Query("DELETE FROM user_fav_listings WHERE user_id = :userId AND listing_id = :listingId")
+    suspend fun deleteFavoriteListing(userId: String, listingId: String)
+}

--- a/app/src/main/java/com/studhub/app/data/local/database/Converters.kt
+++ b/app/src/main/java/com/studhub/app/data/local/database/Converters.kt
@@ -1,0 +1,39 @@
+package com.studhub.app.data.local.database
+
+import androidx.room.TypeConverter
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.util.*
+
+class Converters {
+    @TypeConverter
+    fun fromTimestamp(value: Long?): Date? {
+        return value?.let { Date(it) }
+    }
+
+    @TypeConverter
+    fun dateToTimestamp(date: Date?): Long? {
+        return date?.time
+    }
+
+    @TypeConverter
+    fun fromStringToListOfStrings(value: String?): List<String>? {
+        return value?.let { Json.decodeFromString(it) }
+    }
+
+    @TypeConverter
+    fun listOfStringsToString(list: List<String>?): String {
+        return Json.encodeToString(list)
+    }
+
+    @TypeConverter
+    fun fromStringToMapOfStringBool(value: String?): Map<String, Boolean>? {
+        return value?.let { Json.decodeFromString(it) }
+    }
+
+    @TypeConverter
+    fun mapOfStringBoolToString(map: Map<String, Boolean>?): String {
+        return Json.encodeToString(map)
+    }
+}

--- a/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
+++ b/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
@@ -12,7 +12,7 @@ import com.studhub.app.domain.model.User
 
 @Database(
     entities = [User::class, Conversation::class, Message::class, Listing::class, UserFavoriteListings::class],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
+++ b/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
@@ -1,20 +1,19 @@
 package com.studhub.app.data.local.database
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
-import com.studhub.app.data.local.dao.ConversationDao
-import com.studhub.app.data.local.dao.ListingDao
-import com.studhub.app.data.local.dao.MessageDao
-import com.studhub.app.data.local.dao.UserDao
+import com.studhub.app.data.local.dao.*
+import com.studhub.app.data.local.entity.UserFavoriteListings
 import com.studhub.app.domain.model.Conversation
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.Message
 import com.studhub.app.domain.model.User
 
 @Database(
-    entities = [User::class, Conversation::class, Message::class, Listing::class],
-    version = 1,
+    entities = [User::class, Conversation::class, Message::class, Listing::class, UserFavoriteListings::class],
+    version = 5,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -23,4 +22,5 @@ abstract class LocalAppDatabase : RoomDatabase() {
     abstract fun conversationDao(): ConversationDao
     abstract fun messageDao(): MessageDao
     abstract fun listingDao(): ListingDao
+    abstract fun userFavListingsDao(): UserFavListingsDao
 }

--- a/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
+++ b/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
@@ -1,6 +1,5 @@
 package com.studhub.app.data.local.database
 
-import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters

--- a/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
+++ b/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
@@ -1,0 +1,26 @@
+package com.studhub.app.data.local.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.studhub.app.data.local.dao.ConversationDao
+import com.studhub.app.data.local.dao.ListingDao
+import com.studhub.app.data.local.dao.MessageDao
+import com.studhub.app.data.local.dao.UserDao
+import com.studhub.app.domain.model.Conversation
+import com.studhub.app.domain.model.Listing
+import com.studhub.app.domain.model.Message
+import com.studhub.app.domain.model.User
+
+@Database(
+    entities = [User::class, Conversation::class, Message::class, Listing::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(Converters::class)
+abstract class LocalAppDatabase : RoomDatabase() {
+    abstract fun userDao(): UserDao
+    abstract fun conversationDao(): ConversationDao
+    abstract fun messageDao(): MessageDao
+    abstract fun listingDao(): ListingDao
+}

--- a/app/src/main/java/com/studhub/app/data/local/entity/UserFavoriteListings.kt
+++ b/app/src/main/java/com/studhub/app/data/local/entity/UserFavoriteListings.kt
@@ -1,0 +1,12 @@
+package com.studhub.app.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+
+@Entity(tableName = "user_fav_listings", primaryKeys = ["user_id", "listing_id"])
+data class UserFavoriteListings(
+    @ColumnInfo(name = "user_id")
+    val userId: String,
+    @ColumnInfo(name = "listing_id")
+    val listingId: String
+)

--- a/app/src/main/java/com/studhub/app/data/network/NetworkStatus.kt
+++ b/app/src/main/java/com/studhub/app/data/network/NetworkStatus.kt
@@ -1,0 +1,17 @@
+package com.studhub.app.data.network
+
+import kotlinx.coroutines.flow.Flow
+
+interface NetworkStatus {
+    /**
+     * Current connectivity status (true iff the app has access to the internet)
+     */
+    val isConnected: Boolean
+
+    /**
+     * Subscribe to connectivity status updates
+     *
+     * @return [Flow] of connectivity statuses (true iff the app has access to the internet)
+     */
+    fun connectivityStatus(): Flow<Boolean>
+}

--- a/app/src/main/java/com/studhub/app/data/network/NetworkStatusImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/network/NetworkStatusImpl.kt
@@ -1,0 +1,37 @@
+package com.studhub.app.data.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+
+class NetworkStatusImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : NetworkStatus {
+
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    override val isConnected: Boolean
+        get() = connectivityManager.isDefaultNetworkActive
+
+    override fun connectivityStatus(): Flow<Boolean> = callbackFlow {
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                trySend(true)
+            }
+
+            override fun onLost(network: Network) {
+                trySend(false)
+            }
+        }
+
+        connectivityManager.registerDefaultNetworkCallback(callback)
+
+        awaitClose { connectivityManager.unregisterNetworkCallback(callback) }
+    }
+}

--- a/app/src/main/java/com/studhub/app/data/network/NetworkStatusImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/network/NetworkStatusImpl.kt
@@ -16,19 +16,23 @@ class NetworkStatusImpl @Inject constructor(
     private val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
-    override val isConnected: Boolean
-        get() = connectivityManager.isDefaultNetworkActive
+    override var isConnected: Boolean = connectivityManager.activeNetwork != null
+        private set
 
     override fun connectivityStatus(): Flow<Boolean> = callbackFlow {
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
+                isConnected = true
                 trySend(true)
             }
 
             override fun onLost(network: Network) {
+                isConnected = false
                 trySend(false)
             }
         }
+
+        connectivityManager.isDefaultNetworkActive
 
         connectivityManager.registerDefaultNetworkCallback(callback)
 

--- a/app/src/main/java/com/studhub/app/data/repository/ConversationRepositoryImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/repository/ConversationRepositoryImpl.kt
@@ -3,11 +3,12 @@ package com.studhub.app.data.repository
 import android.util.Log
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
-import com.google.firebase.database.ktx.database
 import com.google.firebase.database.ktx.getValue
-import com.google.firebase.ktx.Firebase
 import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.domain.model.Conversation
 import com.studhub.app.domain.model.Message
 import com.studhub.app.domain.model.User
@@ -17,19 +18,30 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.tasks.await
 import java.util.*
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ConversationRepositoryImpl : ConversationRepository {
+class ConversationRepositoryImpl @Inject constructor(
+    private val remoteDb: FirebaseDatabase,
+    private val localDb: LocalDataSource,
+    private val networkStatus: NetworkStatus
+) : ConversationRepository {
 
-    private val db = Firebase.database.getReference("conversations")
-    private val userDb = Firebase.database.getReference("users")
+    private val db = remoteDb.getReference("conversations")
+    private val userDb = remoteDb.getReference("users")
 
     override suspend fun createConversation(conversation: Conversation): Flow<ApiResponse<Conversation>> =
         flow {
             emit(ApiResponse.Loading)
+
+            if (!networkStatus.isConnected) {
+                emit(ApiResponse.NO_INTERNET_CONNECTION)
+                return@flow
+            }
 
             // first check that the user is not trying to contact themself
             if (conversation.user1Id == conversation.user2Id) {
@@ -109,6 +121,19 @@ class ConversationRepositoryImpl : ConversationRepository {
         flow {
             emit(ApiResponse.Loading)
 
+            if (!networkStatus.isConnected) {
+                emit(
+                    ApiResponse.Success(
+                        // reorder just in case 2 users used the same phone and sent each other some messages
+                        maybeSwitchUsers(
+                            getCachedConversation(conversationId),
+                            user
+                        )
+                    )
+                )
+                return@flow
+            }
+
             val query = db.child(conversationId).get()
 
             query.await()
@@ -131,10 +156,16 @@ class ConversationRepositoryImpl : ConversationRepository {
         callbackFlow {
             trySend(ApiResponse.Loading)
 
+            if (!networkStatus.isConnected) {
+                // reorder just in case 2 users used the same phone and sent each other some messages
+                val conversations =
+                    getCachedConversations(user.id).map { maybeSwitchUsers(it, user) }
+                trySend(ApiResponse.Success(conversations))
+            }
+
             val listener = object : ValueEventListener {
                 override fun onDataChange(dataSnapshot: DataSnapshot) {
                     val conversations = mutableListOf<Conversation>()
-
 
                     dataSnapshot.children.forEach { snapshot ->
                         val conversation = snapshot.getValue(Conversation::class.java)
@@ -143,7 +174,9 @@ class ConversationRepositoryImpl : ConversationRepository {
                                             conversation.user2Id == user.id)
                         ) {
                             // ensure logged-in user is User1
-                            conversations.add(maybeSwitchUsers(conversation, user))
+                            val conv: Conversation = maybeSwitchUsers(conversation, user)
+                            cacheConversation(conv)
+                            conversations.add(conv)
                         }
                     }
 
@@ -170,6 +203,11 @@ class ConversationRepositoryImpl : ConversationRepository {
         message: Message
     ): Flow<ApiResponse<Conversation>> = flow {
         emit(ApiResponse.Loading)
+
+        if (!networkStatus.isConnected) {
+            emit(ApiResponse.NO_INTERNET_CONNECTION)
+            return@flow
+        }
 
         val conversationToPush =
             conversation.copy(updatedAt = Date(), lastMessageContent = message.content)
@@ -201,5 +239,19 @@ class ConversationRepositoryImpl : ConversationRepository {
                 user1 = conversation.user2,
                 user2 = conversation.user1
             )
+
+    private fun cacheConversation(conversation: Conversation) {
+        runBlocking {
+            localDb.saveConversation(conversation)
+        }
+    }
+
+    private suspend fun getCachedConversations(userId: String): List<Conversation> {
+        return localDb.getConversations(userId)
+    }
+
+    private suspend fun getCachedConversation(conversationId: String): Conversation {
+        return localDb.getConversation(conversationId)
+    }
 }
 

--- a/app/src/main/java/com/studhub/app/data/repository/ListingRepositoryImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/repository/ListingRepositoryImpl.kt
@@ -1,20 +1,26 @@
 package com.studhub.app.data.repository
 
-import com.google.firebase.database.ktx.database
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.database.FirebaseDatabase
 import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.data.storage.StorageHelper
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.repository.ListingRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class ListingRepositoryImpl : ListingRepository {
+class ListingRepositoryImpl @Inject constructor(
+    private val remoteDb: FirebaseDatabase,
+    private val localDb: LocalDataSource,
+    private val networkStatus: NetworkStatus
+) : ListingRepository {
 
-    private val db = Firebase.database.getReference("listings")
+    private val db = remoteDb.getReference("listings")
     private var provisionalListing = mutableListOf<Listing>()
     private val storageHelper = StorageHelper()
 
@@ -24,6 +30,11 @@ class ListingRepositoryImpl : ListingRepository {
 
         return flow {
             emit(ApiResponse.Loading)
+
+            if (!networkStatus.isConnected) {
+                emit(ApiResponse.NO_INTERNET_CONNECTION)
+                return@flow
+            }
 
             // store pictures
             val listingToPush = listing.copy(
@@ -48,6 +59,11 @@ class ListingRepositoryImpl : ListingRepository {
 
     override suspend fun getListings(): Flow<ApiResponse<List<Listing>>> = flow {
         emit(ApiResponse.Loading)
+
+        if (!networkStatus.isConnected) {
+            emit(ApiResponse.NO_INTERNET_CONNECTION)
+            return@flow
+        }
 
         val query = db.get()
 
@@ -74,6 +90,11 @@ class ListingRepositoryImpl : ListingRepository {
     override suspend fun getListing(listingId: String): Flow<ApiResponse<Listing>> = flow {
         emit(ApiResponse.Loading)
 
+        if (!networkStatus.isConnected) {
+            emit(ApiResponse.NO_INTERNET_CONNECTION)
+            return@flow
+        }
+
         val query = db.child(listingId).get()
 
         query.await()
@@ -94,51 +115,61 @@ class ListingRepositoryImpl : ListingRepository {
     override suspend fun getListingsBySearch(
         keyword: String,
         blockedUsers: Map<String, Boolean>
-    ): Flow<ApiResponse<List<Listing>>> =
-        flow {
-            emit(ApiResponse.Loading)
-            val query = db.get()
+    ): Flow<ApiResponse<List<Listing>>> = flow {
+        emit(ApiResponse.Loading)
 
-            query.await()
+        if (!networkStatus.isConnected) {
+            emit(ApiResponse.NO_INTERNET_CONNECTION)
+            return@flow
+        }
 
-            if (query.isSuccessful) {
-                val listings = mutableListOf<Listing>()
+        val query = db.get()
 
-                query.result.children.forEach { snapshot ->
-                    val listing = snapshot.getValue(Listing::class.java)
-                    if (listing != null && (blockedUsers[listing.seller.id] != true) &&
-                        (listing.name.contains(keyword, true) || listing.description.contains(
-                            keyword,
-                            true
-                        )
-                                || listing.price.toString().contains(keyword, true))
+        query.await()
+
+        if (query.isSuccessful) {
+            val listings = mutableListOf<Listing>()
+
+            query.result.children.forEach { snapshot ->
+                val listing = snapshot.getValue(Listing::class.java)
+                if (listing != null && (blockedUsers[listing.seller.id] != true) &&
+                    (listing.name.contains(keyword, true) || listing.description.contains(
+                        keyword,
+                        true
+                    )
+                            || listing.price.toString().contains(keyword, true))
+                ) {
+                    listings.add(listing)
+                }
+
+                //TODO - later
+                // Sam implemented his price filtering that way but it's not a robust implementation
+                // Instead, extend the ListingRepository with a method getListingsByPriceRange()
+                if (listing != null && keyword.contains('-')) {
+                    if (listing.price >= keyword.substringBefore('-').toFloat()
+                        && listing.price <= keyword.substringAfter('-').toFloat()
                     ) {
                         listings.add(listing)
                     }
-
-                    //TODO - later
-                    // Sam implemented his price filtering that way but it's not a robust implementation
-                    // Instead, extend the ListingRepository with a method getListingsByPriceRange()
-                    if (listing != null && keyword.contains('-')) {
-                        if (listing.price >= keyword.substringBefore('-').toFloat()
-                            && listing.price <= keyword.substringAfter('-').toFloat()
-                        ) {
-                            listings.add(listing)
-                        }
-                    }
                 }
-                emit(ApiResponse.Success(listings))
-            } else {
-                val errorMessage = query.exception?.message.orEmpty()
-                emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
             }
+            emit(ApiResponse.Success(listings))
+        } else {
+            val errorMessage = query.exception?.message.orEmpty()
+            emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
         }
+    }
 
     override suspend fun getListingsByRange(
         keyword1: String,
         keyword2: String
     ): Flow<ApiResponse<List<Listing>>> = flow {
         emit(ApiResponse.Loading)
+
+        if (!networkStatus.isConnected) {
+            emit(ApiResponse.NO_INTERNET_CONNECTION)
+            return@flow
+        }
 
         val query = db.get()
         query.await()
@@ -175,6 +206,11 @@ class ListingRepositoryImpl : ListingRepository {
     ): Flow<ApiResponse<Listing>> = flow {
         emit(ApiResponse.Loading)
 
+        if (!networkStatus.isConnected) {
+            emit(ApiResponse.NO_INTERNET_CONNECTION)
+            return@flow
+        }
+
         val listingToPush = updatedListing.copy(id = listingId)
         // set the new value of the Listing on the database
         val query = db.child(listingId).setValue(listingToPush)
@@ -192,6 +228,11 @@ class ListingRepositoryImpl : ListingRepository {
 
     override suspend fun removeListing(listingId: String): Flow<ApiResponse<Boolean>> = flow {
         emit(ApiResponse.Loading)
+
+        if (!networkStatus.isConnected) {
+            emit(ApiResponse.NO_INTERNET_CONNECTION)
+            return@flow
+        }
 
         // remove the old value on the database
         val query = db.child(listingId).removeValue()

--- a/app/src/main/java/com/studhub/app/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/repository/UserRepositoryImpl.kt
@@ -1,10 +1,14 @@
 package com.studhub.app.data.repository
 
 import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ktx.database
 import com.google.firebase.database.ktx.getValue
 import com.google.firebase.ktx.Firebase
 import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.core.utils.ApiResponse.Companion.NO_INTERNET_CONNECTION
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.data.storage.StorageHelper
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.Rating
@@ -13,11 +17,16 @@ import com.studhub.app.domain.repository.UserRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class UserRepositoryImpl : UserRepository {
-    private val db: DatabaseReference = Firebase.database.getReference("users")
+class UserRepositoryImpl @Inject constructor(
+    private val remoteDb: FirebaseDatabase,
+    private val localDb: LocalDataSource,
+    private val networkStatus: NetworkStatus
+) : UserRepository {
+    private val db: DatabaseReference = remoteDb.getReference("users")
     private val storageHelper = StorageHelper()
 
     override suspend fun createUser(user: User): Flow<ApiResponse<User>> {
@@ -26,6 +35,11 @@ class UserRepositoryImpl : UserRepository {
 
         return flow {
             emit(ApiResponse.Loading)
+
+            if (!networkStatus.isConnected) {
+                emit(NO_INTERNET_CONNECTION)
+                return@flow
+            }
 
             val query = db.child(userId).setValue(userToPush)
 
@@ -43,6 +57,18 @@ class UserRepositoryImpl : UserRepository {
     override suspend fun getUser(userId: String): Flow<ApiResponse<User>> = flow {
         emit(ApiResponse.Loading)
 
+        // fetch user from cached data if no internet connection
+        if (!networkStatus.isConnected) {
+            val user: User? = getCachedUser(userId)
+            if (user == null) {
+                emit(NO_INTERNET_CONNECTION)
+            } else {
+                emit(ApiResponse.Success(user))
+            }
+
+            return@flow
+        }
+
         val query = db.child(userId).get()
 
         query.await()
@@ -52,6 +78,7 @@ class UserRepositoryImpl : UserRepository {
             if (retrievedUser == null) {
                 emit(ApiResponse.Failure("User does not exist"))
             } else {
+                cacheUser(retrievedUser)
                 emit(ApiResponse.Success(retrievedUser))
             }
         } else {
@@ -66,12 +93,17 @@ class UserRepositoryImpl : UserRepository {
     ): Flow<ApiResponse<User>> = flow {
         emit(ApiResponse.Loading)
 
+        if (!networkStatus.isConnected) {
+            emit(NO_INTERNET_CONNECTION)
+            return@flow
+        }
+
         var profilePicture = updatedUser.profilePicture
 
         // replace profile picture if there is a new one
         // in the future, we may want to remove the previous profile picture
         if (updatedUser.profilePictureUri != null) {
-            profilePicture = storageHelper.storePicture(updatedUser.profilePictureUri, "users")
+            profilePicture = storageHelper.storePicture(updatedUser.profilePictureUri!!, "users")
         }
 
         val query = db.child(userId).updateChildren(
@@ -94,6 +126,7 @@ class UserRepositoryImpl : UserRepository {
             if (retrievedUpdatedUser == null) {
                 emit(ApiResponse.Failure("An error occurred while retrieving the updated user"))
             } else {
+                cacheUser(retrievedUpdatedUser)
                 emit(ApiResponse.Success(retrievedUpdatedUser))
             }
         } else {
@@ -112,6 +145,11 @@ class UserRepositoryImpl : UserRepository {
     ): Flow<ApiResponse<User>> = flow {
         emit(ApiResponse.Loading)
 
+        if (!networkStatus.isConnected) {
+            emit(NO_INTERNET_CONNECTION)
+            return@flow
+        }
+
         val userRef = db.child(userId)
         val favoriteListingsRef = userRef.child("favoriteListings").child(favListingId)
 
@@ -122,7 +160,8 @@ class UserRepositoryImpl : UserRepository {
         val user: User? = userQuery.result.getValue(User::class.java)
 
         if (user != null) {
-            val updatedFavoriteListings = user.favoriteListings.toMutableMap().apply { put(favListingId, true) }
+            val updatedFavoriteListings =
+                user.favoriteListings.toMutableMap().apply { put(favListingId, true) }
             val updatedUser = user.copy(favoriteListings = updatedFavoriteListings)
             val query = favoriteListingsRef.setValue(true)
 
@@ -143,6 +182,11 @@ class UserRepositoryImpl : UserRepository {
     ): Flow<ApiResponse<User>> = flow {
         emit(ApiResponse.Loading)
 
+        if (!networkStatus.isConnected) {
+            emit(NO_INTERNET_CONNECTION)
+            return@flow
+        }
+
         val userRef = db.child(userId)
         val favoriteListingsRef = userRef.child("favoriteListings").child(favListingId)
 
@@ -153,7 +197,8 @@ class UserRepositoryImpl : UserRepository {
         val user: User? = userQuery.result.getValue(User::class.java)
 
         if (user != null) {
-            val updatedFavoriteListings = user.favoriteListings.toMutableMap().apply { remove(favListingId) }
+            val updatedFavoriteListings =
+                user.favoriteListings.toMutableMap().apply { remove(favListingId) }
             val updatedUser = user.copy(favoriteListings = updatedFavoriteListings)
             val query = favoriteListingsRef.setValue(null)
 
@@ -171,6 +216,11 @@ class UserRepositoryImpl : UserRepository {
     override suspend fun getFavoriteListings(userId: String): Flow<ApiResponse<List<Listing>>> =
         flow {
             emit(ApiResponse.Loading)
+
+            if (!networkStatus.isConnected) {
+                emit(NO_INTERNET_CONNECTION)
+                return@flow
+            }
 
             val userRef = db.child(userId)
             val favoriteListingsRef = userRef.child("favoriteListings")
@@ -202,42 +252,15 @@ class UserRepositoryImpl : UserRepository {
             }
         }
 
-    override suspend fun unblockUser(
-        userId: String,
-        blockedUserId: String
-    ): Flow<ApiResponse<User>> = flow {
-        emit(ApiResponse.Loading)
-
-        val userRef = db.child(userId)
-        val blockedUsersRef = userRef.child("blockedUsers").child(blockedUserId)
-
-        val userQuery = userRef.get()
-
-        userQuery.await()
-
-        val user: User? = userQuery.result.getValue(User::class.java)
-
-        if (user != null) {
-            val updatedBlockedUsers =
-                user.blockedUsers.toMutableMap().apply { remove(blockedUserId) }
-            val updatedUser = user.copy(favoriteListings = updatedBlockedUsers)
-            val query = blockedUsersRef.setValue(null)
-
-            query.await()
-
-            if (query.isSuccessful) {
-                emit(ApiResponse.Success(updatedUser))
-            } else {
-                val errorMessage = query.exception?.message.orEmpty()
-                emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
-            }
-        }
-    }
-
     override suspend fun blockUser(
         userId: String, blockedUserId: String
     ): Flow<ApiResponse<User>> = flow {
         emit(ApiResponse.Loading)
+
+        if (!networkStatus.isConnected) {
+            emit(NO_INTERNET_CONNECTION)
+            return@flow
+        }
 
         val userRef = db.child(userId)
         val blockedUsersRef = userRef.child("blockedUsers").child(blockedUserId)
@@ -265,24 +288,66 @@ class UserRepositoryImpl : UserRepository {
         }
     }
 
-    override suspend fun addRating(userId: String, rating: Rating): Flow<ApiResponse<Rating>> = flow {
+    override suspend fun unblockUser(
+        userId: String,
+        blockedUserId: String
+    ): Flow<ApiResponse<User>> = flow {
         emit(ApiResponse.Loading)
 
-        val ratingId: String = db.child(userId).child("ratings").push().key.orEmpty()
-        val ratingToPush: Rating = rating.copy(id = ratingId)
+        if (!networkStatus.isConnected) {
+            emit(NO_INTERNET_CONNECTION)
+            return@flow
+        }
 
-        val query = db.child(userId).child("ratings").child(ratingId).setValue(ratingToPush)
-        query.await()
+        val userRef = db.child(userId)
+        val blockedUsersRef = userRef.child("blockedUsers").child(blockedUserId)
 
-        if (query.isSuccessful) {
-            emit(ApiResponse.Success(ratingToPush))
-        } else {
-            val errorMessage = query.exception?.message.orEmpty()
-            emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
+        val userQuery = userRef.get()
+
+        userQuery.await()
+
+        val user: User? = userQuery.result.getValue(User::class.java)
+
+        if (user != null) {
+            val updatedBlockedUsers =
+                user.blockedUsers.toMutableMap().apply { remove(blockedUserId) }
+            val updatedUser = user.copy(favoriteListings = updatedBlockedUsers)
+            val query = blockedUsersRef.setValue(null)
+
+            query.await()
+
+            if (query.isSuccessful) {
+                emit(ApiResponse.Success(updatedUser))
+            } else {
+                val errorMessage = query.exception?.message.orEmpty()
+                emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
+            }
         }
     }
 
-    override suspend fun updateRating(userId: String, ratingId: String, rating: Rating): Flow<ApiResponse<Rating>> = flow {
+    override suspend fun addRating(userId: String, rating: Rating): Flow<ApiResponse<Rating>> =
+        flow {
+            emit(ApiResponse.Loading)
+
+            val ratingId: String = db.child(userId).child("ratings").push().key.orEmpty()
+            val ratingToPush: Rating = rating.copy(id = ratingId)
+
+            val query = db.child(userId).child("ratings").child(ratingId).setValue(ratingToPush)
+            query.await()
+
+            if (query.isSuccessful) {
+                emit(ApiResponse.Success(ratingToPush))
+            } else {
+                val errorMessage = query.exception?.message.orEmpty()
+                emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
+            }
+        }
+
+    override suspend fun updateRating(
+        userId: String,
+        ratingId: String,
+        rating: Rating
+    ): Flow<ApiResponse<Rating>> = flow {
         emit(ApiResponse.Loading)
 
         val query = db.child(userId).child("ratings").child(ratingId).setValue(rating)
@@ -296,7 +361,10 @@ class UserRepositoryImpl : UserRepository {
         }
     }
 
-    override suspend fun deleteRating(userId: String, ratingId: String): Flow<ApiResponse<Boolean>> = flow {
+    override suspend fun deleteRating(
+        userId: String,
+        ratingId: String
+    ): Flow<ApiResponse<Boolean>> = flow {
         emit(ApiResponse.Loading)
 
         val query = db.child(userId).child("ratings").child(ratingId).removeValue()
@@ -328,11 +396,18 @@ class UserRepositoryImpl : UserRepository {
             }
 
             emit(ApiResponse.Success(ratingsList))
-        }  else {
+        } else {
             val errorMessage = query.exception?.message.orEmpty()
             emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
         }
     }
 
+    private suspend fun cacheUser(user: User) {
+        localDb.saveUser(user)
+    }
+
+    private suspend fun getCachedUser(userId: String): User? {
+        return localDb.getUser(userId)
+    }
 
 }

--- a/app/src/main/java/com/studhub/app/di/AppModule.kt
+++ b/app/src/main/java/com/studhub/app/di/AppModule.kt
@@ -42,7 +42,9 @@ class AppModule {
             context,
             LocalAppDatabase::class.java,
             "studhub-local-db"
-        ).build()
+        )
+            .fallbackToDestructiveMigration()
+            .build()
 
     @Provides
     fun provideLocalDatasource(localDatabase: LocalAppDatabase) = LocalDataSource(localDatabase)
@@ -76,7 +78,11 @@ class AppModule {
 
     @Singleton
     @Provides
-    fun provideListingRepository(): ListingRepository = ListingRepositoryImpl()
+    fun provideListingRepository(
+        remoteDb: FirebaseDatabase,
+        localDb: LocalDataSource,
+        networkStatus: NetworkStatus
+    ): ListingRepository = ListingRepositoryImpl(remoteDb, localDb, networkStatus)
 
     @Singleton
     @Provides
@@ -84,11 +90,19 @@ class AppModule {
 
     @Singleton
     @Provides
-    fun provideConversationRepository(): ConversationRepository = ConversationRepositoryImpl()
+    fun provideConversationRepository(
+        remoteDb: FirebaseDatabase,
+        localDb: LocalDataSource,
+        networkStatus: NetworkStatus
+    ): ConversationRepository = ConversationRepositoryImpl(remoteDb, localDb, networkStatus)
 
     @Singleton
     @Provides
-    fun provideMessageRepository(): MessageRepository = MessageRepositoryImpl()
+    fun provideMessageRepository(
+        remoteDb: FirebaseDatabase,
+        localDb: LocalDataSource,
+        networkStatus: NetworkStatus
+    ): MessageRepository = MessageRepositoryImpl(remoteDb, localDb, networkStatus)
 
     @Provides
     fun provideGetCurrentUserUseCase(

--- a/app/src/main/java/com/studhub/app/di/AppModule.kt
+++ b/app/src/main/java/com/studhub/app/di/AppModule.kt
@@ -1,10 +1,13 @@
 package com.studhub.app.di
 
+import android.content.Context
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
+import com.studhub.app.data.network.NetworkStatus
+import com.studhub.app.data.network.NetworkStatusImpl
 import com.studhub.app.data.repository.*
 import com.studhub.app.domain.repository.*
 import com.studhub.app.domain.usecase.category.GetCategories
@@ -15,6 +18,7 @@ import com.studhub.app.domain.usecase.user.*
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
@@ -27,6 +31,11 @@ class AppModule {
 
     @Provides
     fun provideFirebaseDatabase() = Firebase.database
+
+    @Provides
+    @Singleton
+    fun provideNetworkStatus(@ApplicationContext context: Context): NetworkStatus =
+        NetworkStatusImpl(context)
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/studhub/app/domain/model/Conversation.kt
+++ b/app/src/main/java/com/studhub/app/domain/model/Conversation.kt
@@ -1,16 +1,25 @@
 package com.studhub.app.domain.model
 
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.PrimaryKey
 import java.util.*
 
+@Entity(tableName = "conversation")
 data class Conversation(
-    val id: String = "",
-    val user1Id: String = "",
-    val user2Id: String = "",
-    val user1Name: String = "",
-    val user2Name: String = "",
-    val user1: User? = null,
-    val user2: User? = null,
-    val createdAt: Date = Date(),
-    val updatedAt: Date = Date(),
-    val lastMessageContent: String = ""
-)
+    @PrimaryKey
+    var id: String = "",
+    var user1Id: String = "",
+    var user2Id: String = "",
+    var user1Name: String = "",
+    var user2Name: String = "",
+    @Ignore
+    var user1: User? = null,
+    @Ignore
+    var user2: User? = null,
+    var createdAt: Date = Date(),
+    var updatedAt: Date = Date(),
+    var lastMessageContent: String = ""
+) {
+    constructor() : this("")
+}

--- a/app/src/main/java/com/studhub/app/domain/model/Conversation.kt
+++ b/app/src/main/java/com/studhub/app/domain/model/Conversation.kt
@@ -1,5 +1,6 @@
 package com.studhub.app.domain.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -8,6 +9,7 @@ import java.util.*
 @Entity(tableName = "conversation")
 data class Conversation(
     @PrimaryKey
+    @ColumnInfo(name = "conversation_id")
     var id: String = "",
     var user1Id: String = "",
     var user2Id: String = "",

--- a/app/src/main/java/com/studhub/app/domain/model/Listing.kt
+++ b/app/src/main/java/com/studhub/app/domain/model/Listing.kt
@@ -1,17 +1,21 @@
 package com.studhub.app.domain.model
 
 import android.net.Uri
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
+import java.util.*
 
 @Entity(tableName = "listing")
 data class Listing(
     @PrimaryKey
+    @ColumnInfo(name = "listing_id")
     var id: String = "",
     var name: String = "",
     var description: String = "",
     var sellerId: String = "",
+    var createdAt: Date = Date(),
     @Ignore
     var seller: User = User(),
     var price: Float = 0F,

--- a/app/src/main/java/com/studhub/app/domain/model/Listing.kt
+++ b/app/src/main/java/com/studhub/app/domain/model/Listing.kt
@@ -1,15 +1,27 @@
 package com.studhub.app.domain.model
 
 import android.net.Uri
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.PrimaryKey
 
+@Entity(tableName = "listing")
 data class Listing(
-    val id: String = "",
-    val name: String = "",
-    val description: String = "",
-    val seller: User = User(),
-    val price: Float = 0F,
-    val categories: List<Category> = emptyList(),
-    val meetingPoint: MeetingPoint? = MeetingPoint(0.0,0.0),
-    val pictures: List<String> = emptyList(),
-    val picturesUri: List<Uri>? = null
-)
+    @PrimaryKey
+    var id: String = "",
+    var name: String = "",
+    var description: String = "",
+    var sellerId: String = "",
+    @Ignore
+    var seller: User = User(),
+    var price: Float = 0F,
+    @Ignore
+    var categories: List<Category> = emptyList(),
+    @Ignore
+    var meetingPoint: MeetingPoint? = MeetingPoint(0.0,0.0),
+    var pictures: List<String> = emptyList(),
+    @Ignore
+    var picturesUri: List<Uri>? = null
+) {
+    constructor() : this("")
+}

--- a/app/src/main/java/com/studhub/app/domain/model/Message.kt
+++ b/app/src/main/java/com/studhub/app/domain/model/Message.kt
@@ -1,5 +1,6 @@
 package com.studhub.app.domain.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -8,6 +9,7 @@ import java.util.*
 @Entity(tableName = "message")
 data class Message(
     @PrimaryKey
+    @ColumnInfo(name = "message_id")
     var id: String = "",
     var conversationId: String = "",
     @Ignore

--- a/app/src/main/java/com/studhub/app/domain/model/Message.kt
+++ b/app/src/main/java/com/studhub/app/domain/model/Message.kt
@@ -1,14 +1,23 @@
 package com.studhub.app.domain.model
 
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.PrimaryKey
 import java.util.*
 
+@Entity(tableName = "message")
 data class Message(
-    val id: String = "",
-    val conversationId: String = "",
-    val conversation: Conversation? = null,
-    val senderId: String = "",
-    val sender: User? = null,
-    val content: String = "",
-    val image: String? = null,
-    val createdAt: Date = Date()
-)
+    @PrimaryKey
+    var id: String = "",
+    var conversationId: String = "",
+    @Ignore
+    var conversation: Conversation? = null,
+    var senderId: String = "",
+    @Ignore
+    var sender: User? = null,
+    var content: String = "",
+    var image: String? = null,
+    var createdAt: Date = Date()
+) {
+    constructor() : this("")
+}

--- a/app/src/main/java/com/studhub/app/domain/model/User.kt
+++ b/app/src/main/java/com/studhub/app/domain/model/User.kt
@@ -1,19 +1,28 @@
 package com.studhub.app.domain.model
 
 import android.net.Uri
+import androidx.room.Entity
+import androidx.room.Ignore
+import androidx.room.PrimaryKey
 
+@Entity(tableName = "user")
 data class User(
-    val id: String = "",
-    val email: String = "",
-    val phoneNumber: String = "",
-    val firstName: String = "",
-    val lastName: String = "",
-    val userName: String = "",
-    val profilePicture: String = "",
-    val profilePictureUri: Uri? = null,
-    val favoriteListings: Map<String, Boolean> = emptyMap(),
-    val blockedUsers: Map<String, Boolean> = emptyMap(),
-    val ratings: Map<String, Rating> = emptyMap(),
-    val thumbsUpCount: Int = 0,
-    val thumbsDownCount: Int = 0
-    )
+    @PrimaryKey
+    var id: String = "",
+    var email: String = "",
+    var phoneNumber: String = "",
+    var firstName: String = "",
+    var lastName: String = "",
+    var userName: String = "",
+    var profilePicture: String = "",
+    @Ignore
+    var profilePictureUri: Uri? = null,
+    var favoriteListings: Map<String, Boolean> = emptyMap(),
+    var blockedUsers: Map<String, Boolean> = emptyMap(),
+    @Ignore
+    var ratings: Map<String, Rating> = emptyMap(),
+    var thumbsUpCount: Int = 0,
+    var thumbsDownCount: Int = 0
+) {
+    constructor() : this("")
+}

--- a/app/src/main/java/com/studhub/app/domain/model/User.kt
+++ b/app/src/main/java/com/studhub/app/domain/model/User.kt
@@ -1,6 +1,7 @@
 package com.studhub.app.domain.model
 
 import android.net.Uri
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
@@ -8,6 +9,7 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "user")
 data class User(
     @PrimaryKey
+    @ColumnInfo(name = "user_id")
     var id: String = "",
     var email: String = "",
     var phoneNumber: String = "",

--- a/app/src/main/java/com/studhub/app/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/studhub/app/domain/repository/UserRepository.kt
@@ -13,12 +13,12 @@ interface UserRepository {
     suspend fun removeUser(userId: String): Flow<ApiResponse<Boolean>>
     suspend fun addFavoriteListing(
         userId: String,
-        favListingId: String
+        favListing: Listing
     ): Flow<ApiResponse<User>>
 
     suspend fun removeFavoriteListing(
         userId: String,
-        favListingId: String
+        favListing: Listing
     ): Flow<ApiResponse<User>>
 
     suspend fun getFavoriteListings(userId: String): Flow<ApiResponse<List<Listing>>>

--- a/app/src/main/java/com/studhub/app/domain/usecase/user/AddFavoriteListing.kt
+++ b/app/src/main/java/com/studhub/app/domain/usecase/user/AddFavoriteListing.kt
@@ -1,6 +1,7 @@
 package com.studhub.app.domain.usecase.user
 
 import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.User
 import com.studhub.app.domain.repository.AuthRepository
 import com.studhub.app.domain.repository.UserRepository
@@ -23,10 +24,10 @@ class AddFavoriteListing @Inject constructor(
      *
      * @param [favListingId] the ID of the listing to add to the favorite listing
      */
-    suspend operator fun invoke(favListingId: String): Flow<ApiResponse<User>> {
+    suspend operator fun invoke(favListing: Listing): Flow<ApiResponse<User>> {
         return userRepository.addFavoriteListing(
             authRepository.currentUserUid,
-            favListingId
+            favListing
         )
     }
 }

--- a/app/src/main/java/com/studhub/app/domain/usecase/user/RemoveFavoriteListing.kt
+++ b/app/src/main/java/com/studhub/app/domain/usecase/user/RemoveFavoriteListing.kt
@@ -1,6 +1,7 @@
 package com.studhub.app.domain.usecase.user
 
 import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.User
 import com.studhub.app.domain.repository.AuthRepository
 import com.studhub.app.domain.repository.UserRepository
@@ -23,10 +24,10 @@ class RemoveFavoriteListing @Inject constructor(
      *
      * @param [favListingId] the ID of the listing to remove from the favorite listings
      */
-    suspend operator fun invoke(favListingId: String): Flow<ApiResponse<User>> {
+    suspend operator fun invoke(favListing: Listing): Flow<ApiResponse<User>> {
         return userRepository.removeFavoriteListing(
             authRepository.currentUserUid,
-            favListingId
+            favListing
         )
     }
 }

--- a/app/src/main/java/com/studhub/app/presentation/listing/details/DetailedListingScreen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/listing/details/DetailedListingScreen.kt
@@ -1,16 +1,11 @@
 package com.studhub.app.presentation.listing.details
 
 import android.content.Intent
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -25,7 +20,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.google.android.gms.maps.model.LatLng
 import com.studhub.app.MeetingPointPickerActivity
-import androidx.navigation.compose.rememberNavController
 import com.studhub.app.annotations.ExcludeFromGeneratedTestCoverage
 import com.studhub.app.core.utils.ApiResponse
 import com.studhub.app.domain.model.Category
@@ -41,12 +35,11 @@ import com.studhub.app.presentation.ui.common.misc.Spacer
 import com.studhub.app.presentation.ui.common.text.BigLabel
 
 
-
 @Composable
 fun DetailedListingScreen(
     viewModel: DetailedListingViewModel = hiltViewModel(),
     navigateToConversation: (conversationId: String) -> Unit,
-    navController: NavHostController,
+    navigateToRateUser: (userId: String) -> Unit,
     id: String?
 ) {
     LaunchedEffect(id) {
@@ -87,9 +80,8 @@ fun DetailedListingScreen(
                         displayMeetingPoint(LatLng(meetingPoint.latitude, meetingPoint.longitude))
                     }
                 },
-                onRateUserClick = {
-                    navController.navigate("RatingScreen/${listing.seller.id}")
-                })
+                onRateUserClick = { navigateToRateUser(listing.seller.id) }
+            )
         }
     }
 }
@@ -157,6 +149,7 @@ fun Details(
         }
     }
 }
+
 @ExcludeFromGeneratedTestCoverage
 @Preview(showBackground = true)
 @Composable
@@ -173,7 +166,7 @@ fun DetailsPreview() {
         price = 545.45F
     )
     Details(
-          listing = listing,
+        listing = listing,
         onContactSellerClick = { },
         onFavoriteClicked = { },
         isFavorite = true,

--- a/app/src/main/java/com/studhub/app/presentation/listing/details/DetailedListingViewModel.kt
+++ b/app/src/main/java/com/studhub/app/presentation/listing/details/DetailedListingViewModel.kt
@@ -81,13 +81,13 @@ class DetailedListingViewModel @Inject constructor(
                 val listing = (currentListing as ApiResponse.Success<Listing>).data
                 viewModelScope.launch {
                     if (!isFavorite.value) {
-                        addFavoriteListing(listing.id).collect {
+                        addFavoriteListing(listing).collect {
                             if (it is ApiResponse.Success) {
                                 isFavorite.value = true
                             }
                         }
                     } else {
-                        removeFavoriteListing(listing.id).collect {
+                        removeFavoriteListing(listing).collect {
                             if (it is ApiResponse.Success) {
                                 isFavorite.value = false
                             }

--- a/app/src/main/res/values/strings_error.xml
+++ b/app/src/main/res/values/strings_error.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error_network_off">Internet connection lost. Please check your network status.</string>
+    <string name="error_network_on">Internet connection is back!</string>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         m2_version = '1.4.3'
         hilt_version = '2.45'
         hilt_navigation_compose_version = '1.0.0'
-        camerax_version = '1.3.0-alpha06'
+        room_version = "2.5.1"
     }
     repositories {
         // Make sure that you have the following two repositories
@@ -28,6 +28,9 @@ plugins {
     id 'com.android.library' version '7.4.2' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.8.0'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.8.0'
+    id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
 }
 
 allprojects {


### PR DESCRIPTION
Implementing cache system to maintain persistency of the data through network losses.
Not all data will be stored in local cache: only user profile, conversations with their messages and favorite listings.

Also implementing network manager which allows us to get the current status of the network.
On connectivity loss, a message is displayed on the screen of the user to alert them.

#### Code structure of the mainly impacted code

`app.data.local` => Cache config, DAOs (Data Access Object) and everything related to cache
`app.data.network` => Network "manager"
`app.data.repository` => Repository implementations which were updated to make use of the local storage
`app.domain.model` => Domain models which were updated to be storable in the local db


#### Note for reviewer(s)

The big part of the code is in `app.data.{repository, local, network}` and in the tests.
Other modifications (e.g. `app.presentation`) are minor updates related to the updated/added code.
