### PR TITLE
Feature/issue 143 sync offline messages

### DIFF
--- a/app/src/androidTest/java/com/studhub/app/NavigationTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/NavigationTest.kt
@@ -128,6 +128,36 @@ class NavigationTest {
     }
 
     @Test
+    fun clickProfile_navigateToConversations() {
+        composeTestRule
+            .onNodeWithText(str(R.string.home_button_conversations)).assertExists()
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule.onNodeWithText(str(R.string.conversation_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun clickProfile_navigateToConversations() {
+        composeTestRule
+            .onNodeWithText(str(R.string.home_button_conversations)).assertExists()
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule.onNodeWithText(str(R.string.conversation_title)).assertIsDisplayed()
+    }
+
+    @Test
+    fun clickProfile_navigateToConversations() {
+        composeTestRule
+            .onNodeWithText(str(R.string.home_button_conversations)).assertExists()
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule.onNodeWithText(str(R.string.conversation_title)).assertIsDisplayed()
+    }
+
+    @Test
     fun clickCart_navigatesToAboutScreen() {
         composeTestRule
             .onNodeWithText(str(R.string.home_button_about)).assertExists()

--- a/app/src/androidTest/java/com/studhub/app/NavigationTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/NavigationTest.kt
@@ -128,36 +128,6 @@ class NavigationTest {
     }
 
     @Test
-    fun clickProfile_navigateToConversations() {
-        composeTestRule
-            .onNodeWithText(str(R.string.home_button_conversations)).assertExists()
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule.onNodeWithText(str(R.string.conversation_title)).assertIsDisplayed()
-    }
-
-    @Test
-    fun clickProfile_navigateToConversations() {
-        composeTestRule
-            .onNodeWithText(str(R.string.home_button_conversations)).assertExists()
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule.onNodeWithText(str(R.string.conversation_title)).assertIsDisplayed()
-    }
-
-    @Test
-    fun clickProfile_navigateToConversations() {
-        composeTestRule
-            .onNodeWithText(str(R.string.home_button_conversations)).assertExists()
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule.onNodeWithText(str(R.string.conversation_title)).assertIsDisplayed()
-    }
-
-    @Test
     fun clickCart_navigatesToAboutScreen() {
         composeTestRule
             .onNodeWithText(str(R.string.home_button_about)).assertExists()

--- a/app/src/androidTest/java/com/studhub/app/data/NetworkStatusImplTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/NetworkStatusImplTest.kt
@@ -5,8 +5,18 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 class NetworkStatusImplTest : NetworkStatus {
+    private var connectionStatus = true
+
+    fun turnOffConnection() {
+        connectionStatus = false
+    }
+
+    fun turnOnConnection() {
+        connectionStatus = true
+    }
+
     override val isConnected: Boolean
-        get() = true
+        get() = connectionStatus
 
     override fun connectivityStatus(): Flow<Boolean> {
         return flowOf(true)

--- a/app/src/androidTest/java/com/studhub/app/data/local/dao/UnsentMessageDaoTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/local/dao/UnsentMessageDaoTest.kt
@@ -1,0 +1,146 @@
+package com.studhub.app.data.local.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.local.database.LocalAppDatabase
+import com.studhub.app.domain.model.Message
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.util.*
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+class UnsentMessageDaoTest {
+    private lateinit var localDb: LocalAppDatabase
+    private lateinit var cache: LocalDataSource
+
+    private val conversationId = Random.nextLong().toString()
+    private val message1 = Message(
+        conversationId = conversationId,
+        senderId = "Bobby",
+        createdAt = Date(1000),
+        content = Random.nextLong().toString()
+    )
+    private val message2 = Message(
+        conversationId = conversationId,
+        senderId = "Bobby",
+        createdAt = Date(99999),
+        content = Random.nextLong().toString()
+    )
+    private val message3 = Message(
+        senderId = "Bobby",
+        conversationId = Random.nextLong().toString(),
+        content = Random.nextLong().toString()
+    )
+    private val message4 = Message(
+        senderId = "Maddy",
+        conversationId = Random.nextLong().toString(),
+        content = Random.nextLong().toString()
+    )
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        localDb = Room.inMemoryDatabaseBuilder(
+            context, LocalAppDatabase::class.java
+        ).build()
+        cache = LocalDataSource(localDb)
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        localDb.close()
+    }
+
+
+    @Test
+    @Throws(Exception::class)
+    fun setAndGetMessagesByConversation() {
+        // store the latest message between message1 and message2
+        // this is to test that they are retrieved from the oldest to the latest and not in insertion order
+        runBlocking { cache.saveUnsentMessage(message2) }
+
+        runBlocking {
+            cache.saveUnsentMessage(message1)
+            cache.saveUnsentMessage(message3)
+        }
+
+        var messages: List<Message>
+
+        runBlocking { messages = cache.getUnsentMessagesOfConversation(conversationId) }
+
+        assertEquals("The given conversation should only have 2 messages", 2, messages.size)
+        assertEquals(
+            "First message should be the earlier one (message1)",
+            message1.content,
+            messages.first().content
+        )
+        assertEquals(
+            "Second and last message should be the latest message (message2)",
+            message2.content,
+            messages.last().content
+        )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun setAndGetMessagesByUser() {
+        // store the latest message between message1 and message3
+        // this is to test that they are retrieved from the oldest to the latest and not in insertion order
+        runBlocking { cache.saveUnsentMessage(message3) }
+
+        runBlocking {
+            cache.saveUnsentMessage(message1)
+            cache.saveUnsentMessage(message2)
+        }
+
+        var messages: List<Message>
+
+        runBlocking { messages = cache.getUnsentMessagesOfUser("Bobby") }
+
+        assertEquals("The given user should only have 3 messages", 3, messages.size)
+        assertEquals(
+            "First message should be the earlier one (message1)",
+            message1.content,
+            messages.first().content
+        )
+        assertEquals(
+            "Second and last message should be the latest message (message2)",
+            message3.content,
+            messages.last().content
+        )
+    }
+
+    @Test
+    fun removeAllUnsentMessagesOfUserWorksCorrectly() {
+        // store messages
+        runBlocking {
+            cache.saveUnsentMessage(message1) // sent by Bobby
+            cache.saveUnsentMessage(message2) // sent by Bobby
+            cache.saveUnsentMessage(message3) // sent by Bobby
+            cache.saveUnsentMessage(message4) // sent by Maddy
+        }
+
+        // remove all messages sent (in offline mode) by Bobby
+        runBlocking { cache.removeUnsentMessagesOfUser(message1.senderId) }
+
+        var messages: List<Message>
+
+        runBlocking { messages = cache.getUnsentMessagesOfUser("Bobby") }
+
+        assertEquals("Bobby should have no unsent messages", 0, messages.size)
+
+        runBlocking { messages = cache.getUnsentMessagesOfUser("Maddy") }
+
+        assertTrue("Maddy's unsent messages were not removed accidentally", messages.isNotEmpty())
+    }
+}

--- a/app/src/androidTest/java/com/studhub/app/data/repository/MessageRepositoryImplTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/repository/MessageRepositoryImplTest.kt
@@ -2,23 +2,25 @@ package com.studhub.app.data.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.data.local.LocalDataSource
+import com.studhub.app.data.local.database.LocalAppDatabase
 import com.studhub.app.domain.model.Conversation
 import com.studhub.app.domain.model.Message
+import com.studhub.app.domain.model.User
 import com.studhub.app.domain.repository.ConversationRepository
 import com.studhub.app.domain.repository.MessageRepository
 import com.studhub.app.domain.usecase.conversation.SendMessage
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.*
 import javax.inject.Inject
 import kotlin.random.Random
 
@@ -39,9 +41,111 @@ class MessageRepositoryImplTest {
     @Inject
     lateinit var sendMessage: SendMessage
 
+    @Inject
+    lateinit var localDb: LocalAppDatabase
+
     @Before
     fun init() {
         hiltRule.inject()
+    }
+
+    @Test
+    fun bufferedMessagesAreCorrectlyFlushed() {
+        val cache = LocalDataSource(localDb)
+        val senderId = "Bobby-${Random.nextLong()}"
+        lateinit var conversation: Conversation
+
+        // create fake conversation
+        runBlocking {
+            conversationRepository.createConversation(
+                Conversation(
+                    user1Id = senderId,
+                    user2Id = "Maya"
+                )
+            ).collect {
+                when (it) {
+                    is ApiResponse.Loading -> {}
+                    is ApiResponse.Failure -> fail()
+                    is ApiResponse.Success -> conversation = it.data
+                }
+            }
+        }
+
+        val message1 = Message(
+            conversationId = conversation.id,
+            senderId = senderId,
+            createdAt = Date(1000),
+            content = Random.nextLong().toString()
+        )
+        val message2 = Message(
+            conversationId = conversation.id,
+            senderId = senderId,
+            createdAt = Date(99999),
+            content = Random.nextLong().toString()
+        )
+
+        // buffer messages
+        runBlocking {
+            cache.saveUnsentMessage(message1)
+            cache.saveUnsentMessage(message2)
+        }
+
+        // flush messages
+        runBlocking {
+            messageRepository.flushPendingMessages(User(id = senderId)).collect {
+                when (it) {
+                    is ApiResponse.Failure -> fail("flushPendingMessages failed")
+                    is ApiResponse.Loading -> {}
+                    is ApiResponse.Success -> assertTrue(it.data)
+                }
+            }
+        }
+
+        var messages: List<Message>
+
+        runBlocking { messages = cache.getUnsentMessagesOfUser(senderId) }
+
+        assertEquals("Flushed messages should be removed from the buffer", 0, messages.size)
+
+        // fetch flushed messages from the database
+        runBlocking {
+            launch {
+                messageRepository.getConversationMessages(conversation)
+                    .collect {
+                        when (it) {
+                            is ApiResponse.Success -> {
+                                // check there are only 2 messages
+                                assertEquals(
+                                    "Only 2 messages should have been flushed",
+                                    2,
+                                    it.data.size
+                                )
+
+                                // oldest messages should come first
+                                assertEquals(
+                                    "First message correctly retrieved",
+                                    message1.content,
+                                    it.data.first().content
+                                )
+                                assertEquals(
+                                    "Second message correctly retrieved",
+                                    message2.content,
+                                    it.data.last().content
+                                )
+
+                                cancel()
+                            }
+                            is ApiResponse.Failure -> {
+                                fail("Get Conversation Messages returned failure")
+                                cancel()
+                            }
+                            is ApiResponse.Loading -> {}
+                        }
+                    }
+            }
+        }
+
+        localDb.clearAllTables()
     }
 
     @Test

--- a/app/src/androidTest/java/com/studhub/app/di/AppTestModule.kt
+++ b/app/src/androidTest/java/com/studhub/app/di/AppTestModule.kt
@@ -167,10 +167,9 @@ class AppTestModule {
     @Provides
     fun provideSendMessage(
         messageRepository: MessageRepository,
-        conversationRepository: ConversationRepository,
         authRepository: AuthRepository
     ): SendMessage =
-        SendMessage(messageRepository, conversationRepository, authRepository)
+        SendMessage(messageRepository, authRepository)
 
     @Provides
     fun provideStartConversationWith(

--- a/app/src/main/java/com/studhub/app/MainActivity.kt
+++ b/app/src/main/java/com/studhub/app/MainActivity.kt
@@ -17,24 +17,20 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.studhub.app.core.Globals
 import com.studhub.app.core.utils.Utils
-import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.presentation.auth.AuthViewModel
 import com.studhub.app.presentation.nav.NavBar
 import com.studhub.app.presentation.ui.theme.StudHubTheme
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private lateinit var navController: NavHostController
 
-    private val viewModel by viewModels<AuthViewModel>()
+    private val authViewModel by viewModels<AuthViewModel>()
 
-    @Inject
-    lateinit var networkManager: NetworkStatus
+    private val viewModel by viewModels<MainViewModel>()
 
     @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
-    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -65,12 +61,12 @@ class MainActivity : AppCompatActivity() {
 
     @Composable
     private fun AuthState() {
-        val isUserSignedOut = !viewModel.getAuthState().collectAsState().value
+        val isUserSignedOut = !authViewModel.getAuthState().collectAsState().value
         if (isUserSignedOut) {
             Globals.showBottomBar = false
             navController.navigate("Auth")
         } else {
-            if (viewModel.isEmailVerified) {
+            if (authViewModel.isEmailVerified) {
                 Globals.showBottomBar = true
                 navController.navigate("Home")
             } else {
@@ -82,10 +78,12 @@ class MainActivity : AppCompatActivity() {
 
     @Composable
     private fun ConnectivityState() {
-        val networkStatus = networkManager.connectivityStatus().collectAsState(initial = true).value
+        val networkStatus = viewModel.getNetworkState().collectAsState().value
 
         if (!networkStatus) {
             Utils.displayMessage(applicationContext, stringResource(R.string.error_network_off))
+        } else {
+            viewModel.flushCachedMessages()
         }
     }
 

--- a/app/src/main/java/com/studhub/app/MainViewModel.kt
+++ b/app/src/main/java/com/studhub/app/MainViewModel.kt
@@ -1,0 +1,20 @@
+package com.studhub.app
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.studhub.app.data.network.NetworkStatus
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+class MainViewModel @Inject constructor(
+    private val networkStatus: NetworkStatus
+): ViewModel() {
+    fun getNetworkState() = networkStatus.connectivityStatus().stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(),
+        networkStatus.isConnected
+    )
+
+    fun flushCachedMessages() {}
+}

--- a/app/src/main/java/com/studhub/app/MainViewModel.kt
+++ b/app/src/main/java/com/studhub/app/MainViewModel.kt
@@ -2,13 +2,21 @@ package com.studhub.app
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.studhub.app.core.utils.ApiResponse
 import com.studhub.app.data.network.NetworkStatus
+import com.studhub.app.domain.usecase.conversation.FlushPendingMessages
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class MainViewModel @Inject constructor(
-    private val networkStatus: NetworkStatus
+    private val networkStatus: NetworkStatus,
+    private val flushPendingMessages: FlushPendingMessages
 ): ViewModel() {
     fun getNetworkState() = networkStatus.connectivityStatus().stateIn(
         viewModelScope,
@@ -16,5 +24,9 @@ class MainViewModel @Inject constructor(
         networkStatus.isConnected
     )
 
-    fun flushCachedMessages() {}
+    fun flushCachedMessages() {
+        viewModelScope.launch {
+            flushPendingMessages().collect()
+        }
+    }
 }

--- a/app/src/main/java/com/studhub/app/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/studhub/app/data/local/LocalDataSource.kt
@@ -1,6 +1,7 @@
 package com.studhub.app.data.local
 
 import com.studhub.app.data.local.database.LocalAppDatabase
+import com.studhub.app.data.local.entity.UnsentMessage
 import com.studhub.app.data.local.entity.UserFavoriteListings
 import com.studhub.app.domain.model.Conversation
 import com.studhub.app.domain.model.Listing
@@ -14,6 +15,7 @@ class LocalDataSource @Inject constructor(
     private val userDao = localDatabase.userDao()
     private val conversationDao = localDatabase.conversationDao()
     private val messageDao = localDatabase.messageDao()
+    private val unsentMessageDao = localDatabase.unsentMessageDao()
     private val listingDao = localDatabase.listingDao()
     private val userFavListingsDao = localDatabase.userFavListingsDao()
 
@@ -47,6 +49,47 @@ class LocalDataSource @Inject constructor(
 
     suspend fun saveMessage(message: Message) {
         messageDao.insertMessage(message)
+    }
+
+    suspend fun saveUnsentMessage(message: Message) {
+        val unsentMessage = UnsentMessage(
+            id = 0,
+            senderId = message.senderId,
+            conversationId = message.conversationId,
+            content = message.content,
+            image = message.image,
+            createdAt = message.createdAt
+        )
+
+        unsentMessageDao.insertUnsentMessage(unsentMessage)
+    }
+
+    suspend fun removeUnsentMessagesOfUser(userId: String) {
+        unsentMessageDao.deleteUnsentMessages(userId)
+    }
+
+    suspend fun getUnsentMessagesOfConversation(conversationId: String): List<Message> {
+        return unsentMessageDao.getUnsentMessages(conversationId).map {
+            Message(
+                senderId = it.senderId,
+                conversationId = it.conversationId,
+                content = it.content,
+                image = it.image,
+                createdAt = it.createdAt
+            )
+        }
+    }
+
+    suspend fun getUnsentMessagesOfUser(userId: String): List<Message> {
+        return unsentMessageDao.getUnsentMessagesOfUser(userId).map {
+            Message(
+                senderId = it.senderId,
+                conversationId = it.conversationId,
+                content = it.content,
+                image = it.image,
+                createdAt = it.createdAt
+            )
+        }
     }
 
     suspend fun getFavListings(userId: String): List<Listing> {

--- a/app/src/main/java/com/studhub/app/data/local/dao/UnsentMessageDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/UnsentMessageDao.kt
@@ -8,6 +8,9 @@ interface UnsentMessageDao {
     @Query("SELECT * FROM unsent_message WHERE conversationId = :conversationId ORDER BY createdAt ASC")
     suspend fun getUnsentMessages(conversationId: String): List<UnsentMessage>
 
+    @Query("SELECT * FROM unsent_message WHERE senderId = :senderId ORDER BY createdAt ASC")
+    suspend fun getUnsentMessagesOfUser(senderId: String): List<UnsentMessage>
+
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertUnsentMessage(unsentMessage: UnsentMessage)
 

--- a/app/src/main/java/com/studhub/app/data/local/dao/UnsentMessageDao.kt
+++ b/app/src/main/java/com/studhub/app/data/local/dao/UnsentMessageDao.kt
@@ -1,0 +1,16 @@
+package com.studhub.app.data.local.dao
+
+import androidx.room.*
+import com.studhub.app.data.local.entity.UnsentMessage
+
+@Dao
+interface UnsentMessageDao {
+    @Query("SELECT * FROM unsent_message WHERE conversationId = :conversationId ORDER BY createdAt ASC")
+    suspend fun getUnsentMessages(conversationId: String): List<UnsentMessage>
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insertUnsentMessage(unsentMessage: UnsentMessage)
+
+    @Query("DELETE FROM unsent_message WHERE senderId = :senderId")
+    suspend fun deleteUnsentMessages(senderId: String)
+}

--- a/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
+++ b/app/src/main/java/com/studhub/app/data/local/database/LocalAppDatabase.kt
@@ -4,6 +4,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.studhub.app.data.local.dao.*
+import com.studhub.app.data.local.entity.UnsentMessage
 import com.studhub.app.data.local.entity.UserFavoriteListings
 import com.studhub.app.domain.model.Conversation
 import com.studhub.app.domain.model.Listing
@@ -11,8 +12,8 @@ import com.studhub.app.domain.model.Message
 import com.studhub.app.domain.model.User
 
 @Database(
-    entities = [User::class, Conversation::class, Message::class, Listing::class, UserFavoriteListings::class],
-    version = 6,
+    entities = [User::class, Conversation::class, Message::class, UnsentMessage::class, Listing::class, UserFavoriteListings::class],
+    version = 10,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -20,6 +21,7 @@ abstract class LocalAppDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
     abstract fun conversationDao(): ConversationDao
     abstract fun messageDao(): MessageDao
+    abstract fun unsentMessageDao(): UnsentMessageDao
     abstract fun listingDao(): ListingDao
     abstract fun userFavListingsDao(): UserFavListingsDao
 }

--- a/app/src/main/java/com/studhub/app/data/local/entity/UnsentMessage.kt
+++ b/app/src/main/java/com/studhub/app/data/local/entity/UnsentMessage.kt
@@ -1,0 +1,18 @@
+package com.studhub.app.data.local.entity;
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.*
+
+@Entity(tableName = "unsent_message")
+data class UnsentMessage(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "message_id")
+    val id: Int,
+    val conversationId: String = "",
+    val senderId: String = "",
+    val content: String = "",
+    val image: String? = null,
+    val createdAt: Date = Date()
+)

--- a/app/src/main/java/com/studhub/app/data/repository/ConversationRepositoryImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/repository/ConversationRepositoryImpl.kt
@@ -198,32 +198,6 @@ class ConversationRepositoryImpl @Inject constructor(
             }
         }
 
-    override suspend fun updateLastMessageWith(
-        conversation: Conversation,
-        message: Message
-    ): Flow<ApiResponse<Conversation>> = flow {
-        emit(ApiResponse.Loading)
-
-        if (!networkStatus.isConnected) {
-            emit(ApiResponse.NO_INTERNET_CONNECTION)
-            return@flow
-        }
-
-        val conversationToPush =
-            conversation.copy(updatedAt = Date(), lastMessageContent = message.content)
-
-        val query = db.child(conversation.id).setValue(conversationToPush)
-
-        query.await()
-
-        if (query.isSuccessful) {
-            emit(ApiResponse.Success(conversationToPush))
-        } else {
-            val errorMessage = query.exception?.message.orEmpty()
-            emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
-        }
-    }
-
     /**
      * Switch user1 and user2 in the [conversation] so that user1 is the given [currentUser]
      */

--- a/app/src/main/java/com/studhub/app/data/repository/MessageRepositoryImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/repository/MessageRepositoryImpl.kt
@@ -123,7 +123,6 @@ class MessageRepositoryImpl @Inject constructor(
             // on success, remove all flushed messages from the cache
             unbufferAllMessages(user.id)
             emit(ApiResponse.Success(true))
-            unbufferAllMessages(user.id)
         } else {
             val errorMessage = query.exception?.message.orEmpty()
             Log.w("MESSAGE_REPO", errorMessage)

--- a/app/src/main/java/com/studhub/app/data/repository/MessageRepositoryImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/repository/MessageRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.studhub.app.data.repository
 
+import android.util.Log
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
@@ -9,6 +10,7 @@ import com.studhub.app.data.local.LocalDataSource
 import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.domain.model.Conversation
 import com.studhub.app.domain.model.Message
+import com.studhub.app.domain.model.User
 import com.studhub.app.domain.repository.MessageRepository
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
@@ -28,30 +30,28 @@ class MessageRepositoryImpl @Inject constructor(
     private val networkStatus: NetworkStatus
 ) : MessageRepository {
 
-    private val db = remoteDb.getReference("messages")
+    private val rootDb = remoteDb.reference
+    private val db = rootDb.child("messages")
 
-    override suspend fun createMessage(message: Message): Flow<ApiResponse<Message>> {
-        val messageId: String = db.push().key.orEmpty()
-        val messageToPush: Message = message.copy(id = messageId, createdAt = Date())
+    override suspend fun createMessage(message: Message): Flow<ApiResponse<Message>> = flow {
+        emit(ApiResponse.Loading)
 
-        return flow {
-            emit(ApiResponse.Loading)
+        if (!networkStatus.isConnected) {
+            bufferMessage(message)
+            emit(ApiResponse.Success(message))
+            return@flow
+        }
 
-            if (!networkStatus.isConnected) {
-                emit(ApiResponse.NO_INTERNET_CONNECTION)
-                return@flow
-            }
+        val (pushedMessage, updates) = getCreateMessageQuery(message)
 
-            val query = db.child(messageId).setValue(messageToPush)
+        val query = rootDb.updateChildren(updates)
+        query.await()
 
-            query.await()
-
-            if (query.isSuccessful) {
-                emit(ApiResponse.Success(messageToPush))
-            } else {
-                val errorMessage = query.exception?.message.orEmpty()
-                emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
-            }
+        if (query.isSuccessful) {
+            emit(ApiResponse.Success(pushedMessage))
+        } else {
+            val errorMessage = query.exception?.message.orEmpty()
+            emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
         }
     }
 
@@ -60,7 +60,13 @@ class MessageRepositoryImpl @Inject constructor(
             trySend(ApiResponse.Loading)
 
             if (!networkStatus.isConnected) {
-                trySend(ApiResponse.Success(getCachedConversationMessages(conversation.id)))
+                trySend(
+                    ApiResponse.Success(
+                        getCachedConversationMessages(conversation.id) +
+                                // also return unsent messages at the end
+                                getBufferedMessages(conversation.id)
+                    )
+                )
             }
 
             val listener = object : ValueEventListener {
@@ -93,13 +99,77 @@ class MessageRepositoryImpl @Inject constructor(
             }
         }
 
+    override suspend fun flushPendingMessages(user: User): Flow<ApiResponse<Boolean>> = flow {
+        emit(ApiResponse.Loading)
+
+        val messages = getBufferedMessagesOfUser(user.id)
+
+        // if there is no message to flush, just return
+        if (messages.isEmpty()) {
+            emit(ApiResponse.Success(true))
+            return@flow
+        }
+
+        val updates = messages
+            // map the list of messages to a list of pairs of Message and Updates (<path, value>)
+            .map { getCreateMessageQuery(it) }
+            // concatenate the updates to have a single big update (map of <path, value>)
+            .fold(mapOf<String, Any>()) { acc, value -> acc.plus(value.second) }
+
+        val query = rootDb.updateChildren(updates)
+        query.await()
+
+        if (query.isSuccessful) {
+            // on success, remove all flushed messages from the cache
+            unbufferAllMessages(user.id)
+            emit(ApiResponse.Success(true))
+            unbufferAllMessages(user.id)
+        } else {
+            val errorMessage = query.exception?.message.orEmpty()
+            Log.w("MESSAGE_REPO", errorMessage)
+            emit(ApiResponse.Failure("Database error"))
+        }
+    }
+
+    /**
+     * Returns a pair with the first element being the pushed message and the second being the queries to send to the database system
+     *
+     * @param message the message to upload
+     * @return a pair with the first element being the pushed message and the second being the queries to send to the database system
+     */
+    private fun getCreateMessageQuery(message: Message): Pair<Message, Map<String, Any>> {
+        val messageId: String = db.push().key.orEmpty()
+        val messageToPush: Message = message.copy(id = messageId, createdAt = Date())
+
+        val updates = mapOf(
+            "/messages/$messageId" to messageToPush,
+            "/conversations/${message.conversationId}/updatedAt" to Date(),
+            "/conversations/${message.conversationId}/lastMessageContent" to messageToPush.content,
+        )
+
+        return Pair(messageToPush, updates)
+    }
+
     private fun cacheMessage(message: Message) {
         runBlocking {
             localDb.saveMessage(message)
         }
     }
 
-    private suspend fun getCachedConversationMessages(conversationId: String): List<Message> {
-        return localDb.getMessages(conversationId)
+    private suspend fun getCachedConversationMessages(conversationId: String): List<Message> =
+        localDb.getMessages(conversationId)
+
+    private suspend fun bufferMessage(message: Message) {
+        localDb.saveUnsentMessage(message)
     }
+
+    private suspend fun unbufferAllMessages(userId: String) {
+        localDb.removeUnsentMessagesOfUser(userId)
+    }
+
+    private suspend fun getBufferedMessagesOfUser(userId: String): List<Message> =
+        localDb.getUnsentMessagesOfUser(userId)
+
+    private suspend fun getBufferedMessages(conversationId: String): List<Message> =
+        localDb.getUnsentMessagesOfConversation(conversationId)
 }

--- a/app/src/main/java/com/studhub/app/di/AppModule.kt
+++ b/app/src/main/java/com/studhub/app/di/AppModule.kt
@@ -182,10 +182,9 @@ class AppModule {
     @Provides
     fun provideSendMessage(
         messageRepository: MessageRepository,
-        conversationRepository: ConversationRepository,
         authRepository: AuthRepository
     ): SendMessage =
-        SendMessage(messageRepository, conversationRepository, authRepository)
+        SendMessage(messageRepository, authRepository)
 
     @Provides
     fun provideStartConversationWith(

--- a/app/src/main/java/com/studhub/app/domain/repository/ConversationRepository.kt
+++ b/app/src/main/java/com/studhub/app/domain/repository/ConversationRepository.kt
@@ -35,15 +35,4 @@ interface ConversationRepository {
      */
     suspend fun getUserConversations(user: User): Flow<ApiResponse<List<Conversation>>>
 
-    /**
-     * Updates the last message sent to the [conversation] with the content of the given [message]
-     * @param [conversation] the conversation to update
-     * @param [message] the new last message of the [conversation]
-     * @return A [Flow] of [ApiResponse] with the last one containing the [Conversation] updated in the repository on success
-     */
-    suspend fun updateLastMessageWith(
-        conversation: Conversation,
-        message: Message
-    ): Flow<ApiResponse<Conversation>>
-
 }

--- a/app/src/main/java/com/studhub/app/domain/repository/MessageRepository.kt
+++ b/app/src/main/java/com/studhub/app/domain/repository/MessageRepository.kt
@@ -3,6 +3,7 @@ package com.studhub.app.domain.repository
 import com.studhub.app.core.utils.ApiResponse
 import com.studhub.app.domain.model.Conversation
 import com.studhub.app.domain.model.Message
+import com.studhub.app.domain.model.User
 import kotlinx.coroutines.flow.Flow
 
 interface MessageRepository {
@@ -15,9 +16,16 @@ interface MessageRepository {
     suspend fun createMessage(message: Message): Flow<ApiResponse<Message>>
 
     /**
-     * Retrieves all conversations from the repository sent in the given [conversation]
+     * Retrieves all messages from the repository sent in the given [conversation]
      * @param [conversation] the conversation which to retrieve messages from
      * @return A [Flow] of [ApiResponse] with the last one containing the retrieved list of [Message]s on success
      */
     suspend fun getConversationMessages(conversation: Conversation): Flow<ApiResponse<List<Message>>>
+
+    /**
+     * Flushes all (locally) pending messages sent by the given [user] to the repository
+     * @param user the user who sent the messages to flush
+     * @return A [Flow] of [ApiResponse] with the last one containing true iff all messages could be sent
+     */
+    suspend fun flushPendingMessages(user: User): Flow<ApiResponse<Boolean>>
 }

--- a/app/src/main/java/com/studhub/app/domain/usecase/conversation/FlushPendingMessages.kt
+++ b/app/src/main/java/com/studhub/app/domain/usecase/conversation/FlushPendingMessages.kt
@@ -1,0 +1,28 @@
+package com.studhub.app.domain.usecase.conversation
+
+import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.domain.model.Conversation
+import com.studhub.app.domain.model.Message
+import com.studhub.app.domain.model.User
+import com.studhub.app.domain.repository.AuthRepository
+import com.studhub.app.domain.repository.MessageRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * Use case for sending all pending messages to the given [messageRepository]
+ *
+ * @param [messageRepository] the repository which the use case will send the messages to
+ * @param [authRepository] the repository which the use case will retrieve the logged in user from
+ */
+class FlushPendingMessages @Inject constructor(
+    private val messageRepository: MessageRepository,
+    private val authRepository: AuthRepository
+) {
+    /**
+     * Sends all pending messages.
+     */
+    suspend operator fun invoke(): Flow<ApiResponse<Boolean>> {
+        return messageRepository.flushPendingMessages(User(id = authRepository.currentUserUid))
+    }
+}

--- a/app/src/main/java/com/studhub/app/domain/usecase/conversation/SendMessage.kt
+++ b/app/src/main/java/com/studhub/app/domain/usecase/conversation/SendMessage.kt
@@ -18,7 +18,6 @@ import javax.inject.Inject
  */
 class SendMessage @Inject constructor(
     private val messageRepository: MessageRepository,
-    private val conversationRepository: ConversationRepository,
     private val authRepository: AuthRepository
 ) {
 
@@ -32,22 +31,6 @@ class SendMessage @Inject constructor(
         val msg =
             message.copy(senderId = authRepository.currentUserUid, conversationId = conversation.id)
 
-        return flow {
-            messageRepository.createMessage(msg).collect { msgQuery ->
-                when (msgQuery) {
-                    is ApiResponse.Success -> {
-                        conversationRepository.updateLastMessageWith(conversation, msgQuery.data)
-                            .collect { convoQuery ->
-                                when (convoQuery) {
-                                    is ApiResponse.Failure -> emit(ApiResponse.Failure(convoQuery.message))
-                                    is ApiResponse.Loading -> emit(ApiResponse.Loading)
-                                    is ApiResponse.Success -> emit(msgQuery)
-                                }
-                            }
-                    }
-                    else -> emit(msgQuery)
-                }
-            }
-        }
+        return messageRepository.createMessage(msg)
     }
 }

--- a/app/src/main/java/com/studhub/app/presentation/conversation/ConversationScreen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/conversation/ConversationScreen.kt
@@ -25,7 +25,6 @@ fun ConversationScreen(
 
     Column {
         BigLabel(label = stringResource(R.string.conversation_title))
-        
         when (val conversations = viewModel.conversations) {
             is ApiResponse.Loading -> LoadingCircle()
             is ApiResponse.Failure -> {}


### PR DESCRIPTION
Implement synchronization of messages that were sent offline when back online.
A user can now send messages in different conversations while offline -> these messages will be uploaded/flushed to the online database as soon as internet connection is restored (The user does not need to be on the message page, they can be anywhere on the application as long as they are logged in).