### PR TITLE
Feature/add own listings view in profile

### DIFF
--- a/app/src/androidTest/java/com/studhub/app/NavigationTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/NavigationTest.kt
@@ -96,6 +96,22 @@ class NavigationTest {
     }
 
     @Test
+    fun clickProfile_navigateToProfileScreenAndClickOwnListings() {
+        composeTestRule
+            .onNodeWithText(str(R.string.home_button_profile)).assertExists()
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule.onNodeWithText(str(R.string.profile_btn_display_own_listings))
+            .assertExists()
+            .performScrollTo()
+            .performClick()
+
+        composeTestRule.onNodeWithText(str(R.string.profile_own_listings_title))
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun clickProfile_navigateToProfileThenEditThenSave() {
         composeTestRule
             .onNodeWithText(str(R.string.home_button_profile)).assertExists()

--- a/app/src/androidTest/java/com/studhub/app/data/repository/MockListingRepositoryImpl.kt
+++ b/app/src/androidTest/java/com/studhub/app/data/repository/MockListingRepositoryImpl.kt
@@ -3,16 +3,15 @@ package com.studhub.app.data.repository
 import com.studhub.app.core.utils.ApiResponse
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.ListingType
+import com.studhub.app.domain.model.User
 import com.studhub.app.domain.repository.ListingRepository
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.util.*
 import javax.inject.Singleton
-import kotlin.collections.HashMap
 
 @Singleton
-class MockListingRepositoryImpl: ListingRepository {
+class MockListingRepositoryImpl : ListingRepository {
     private val listingDB = HashMap<String, Listing>()
 
     override suspend fun createListing(listing: Listing): Flow<ApiResponse<Listing>> {
@@ -40,19 +39,28 @@ class MockListingRepositoryImpl: ListingRepository {
         }
     }
 
-
-
-    override suspend fun getListingsBySearch(keyword: String,keyword1: String,
-                                             keyword2: String, blockedUsers: Map<String, Boolean>): Flow<ApiResponse<List<Listing>>> {
+    override suspend fun getUserListings(user: User): Flow<ApiResponse<List<Listing>>> {
         return flow {
             emit(ApiResponse.Loading)
-            emit(ApiResponse.Success(listingDB.values.filter { k-> (k.description.compareTo(keyword)==0 || k.name.compareTo(keyword) == 0)
-                    && blockedUsers[k.seller.id] != true}))
+            emit(ApiResponse.Success(listingDB.values.toList()))
         }
     }
 
 
-
+    override suspend fun getListingsBySearch(
+        keyword: String,
+        keyword1: String,
+        keyword2: String,
+        blockedUsers: Map<String, Boolean>
+    ): Flow<ApiResponse<List<Listing>>> {
+        return flow {
+            emit(ApiResponse.Loading)
+            emit(ApiResponse.Success(listingDB.values.filter { k ->
+                (k.description.compareTo(keyword) == 0 || k.name.compareTo(keyword) == 0)
+                        && blockedUsers[k.seller.id] != true
+            }))
+        }
+    }
 
 
     override suspend fun updateListing(

--- a/app/src/androidTest/java/com/studhub/app/presentation/profile/components/ProfileOwnListingsContentTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/presentation/profile/components/ProfileOwnListingsContentTest.kt
@@ -1,0 +1,135 @@
+package com.studhub.app.presentation.profile.components
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.studhub.app.R
+import com.studhub.app.domain.model.Listing
+import dagger.hilt.android.testing.HiltAndroidTest
+import junit.framework.TestCase.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class ProfileOwnListingsContentTest {
+
+    private fun str(id: Int) =
+        InstrumentationRegistry.getInstrumentation().targetContext.getString(id)
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun emptyListOfListingsDisplayCorrectMessage() {
+        val listings: List<Listing> = emptyList()
+
+        composeTestRule.setContent {
+            ProfileOwnListingsContent(
+                listings = listings,
+                navigateToProfile = {},
+                navigateToListing = {},
+                isLoading = false
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(str(R.string.profile_own_listings_no_listings))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun listingsAreCorrectlyDisplayed() {
+        val listing1 = Listing(name = "Listing A")
+        val listing2 = Listing(name = "Listing B")
+        val listing3 = Listing(name = "Listing C")
+        val dummyListing = Listing(name = "Dummy")
+
+        val listings: List<Listing> = listOf(
+            listing1,
+            listing2,
+            dummyListing, dummyListing, dummyListing, dummyListing,
+            dummyListing, dummyListing, dummyListing, dummyListing,
+            dummyListing, dummyListing, dummyListing, dummyListing,
+            dummyListing, dummyListing, dummyListing, dummyListing,
+            dummyListing, dummyListing, dummyListing, dummyListing,
+            listing3,
+        )
+
+        composeTestRule.setContent {
+            ProfileOwnListingsContent(
+                listings = listings,
+                navigateToProfile = {},
+                navigateToListing = {},
+                isLoading = false
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(listing1.name)
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(listing2.name)
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(listing3.name)
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun clickingOnAListingWorksCorrectly() {
+        var clickedId = ""
+        val expectedListingId = "Listing-A"
+        val listingToClickName = "Click me"
+        val listings = listOf(
+            Listing(id = "01234", name = "01234"),
+            Listing(id = expectedListingId, name = listingToClickName),
+            Listing(id = "56789", name = "56789"),
+        )
+
+        composeTestRule.setContent {
+            ProfileOwnListingsContent(
+                listings = listings,
+                navigateToProfile = {},
+                navigateToListing = { id -> clickedId = id },
+                isLoading = false
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText(listingToClickName)
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals("Back to profile button was clicked", expectedListingId, clickedId)
+    }
+
+    @Test
+    fun clickingOnBackButtonWorksCorrectly() {
+        val listings: List<Listing> = emptyList()
+        var clicked = false
+
+        composeTestRule.setContent {
+            ProfileOwnListingsContent(
+                listings = listings,
+                navigateToProfile = { clicked = true },
+                navigateToListing = {},
+                isLoading = false
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(str(R.string.misc_btn_go_back))
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals("Back to profile button was clicked", true, clicked)
+    }
+}

--- a/app/src/androidTest/java/com/studhub/app/presentation/ui/common/container/ScreenTest.kt
+++ b/app/src/androidTest/java/com/studhub/app/presentation/ui/common/container/ScreenTest.kt
@@ -1,0 +1,92 @@
+package com.studhub.app.presentation.ui.common.container
+
+import androidx.compose.material.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.studhub.app.R
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class ScreenTest {
+
+    private fun str(id: Int) =
+        InstrumentationRegistry.getInstrumentation().targetContext.getString(id)
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun titleIsCorrectlyDisplayed() {
+        val title = "Screen title"
+        composeTestRule.setContent {
+            Screen(title = title) {
+                Text(text = "")
+            }
+        }
+
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
+    fun backButtonIsHiddenWhenParamOnGoBackClickIsNull() {
+        val title = "Screen title"
+        composeTestRule.setContent {
+            Screen(title = title) {
+                Text(text = "")
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(str(R.string.misc_btn_go_back))
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun backButtonIsDisplayedWhenParamOnGoBackClickIsNotNull() {
+        val title = "Screen title"
+        val redirectToSomewhere: () -> Unit = {}
+        composeTestRule.setContent {
+            Screen(title = title, onGoBackClick = redirectToSomewhere) {
+                Text(text = "")
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(str(R.string.misc_btn_go_back))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun contentIsCorrectlyDisplayed() {
+        val title = "Screen title"
+        val contentText = "Screen content"
+        composeTestRule.setContent {
+            Screen(title = title) {
+                Text(text = contentText)
+            }
+        }
+
+        composeTestRule.onNodeWithText(contentText).assertIsDisplayed()
+    }
+
+    @Test
+    fun contentIsHiddenWhenScreenIsLoading() {
+        val title = "Screen title"
+        val contentText = "Screen content"
+        composeTestRule.setContent {
+            Screen(title = title, isLoading = true) {
+                Text(text = contentText)
+            }
+        }
+
+        composeTestRule.onNodeWithText(contentText).assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/studhub/app/NavigationComponent.kt
+++ b/app/src/main/java/com/studhub/app/NavigationComponent.kt
@@ -21,6 +21,7 @@ import com.studhub.app.presentation.listing.browse.BrowseScreen
 import com.studhub.app.presentation.listing.details.DetailedListingScreen
 import com.studhub.app.presentation.profile.EditProfileScreen
 import com.studhub.app.presentation.profile.ProfileFavoritesScreen
+import com.studhub.app.presentation.profile.ProfileOwnListingsScreen
 import com.studhub.app.presentation.profile.ProfileScreen
 import com.studhub.app.presentation.ratings.UserRatingScreen
 
@@ -70,6 +71,14 @@ fun AppNavigation(
         composable(route = "Profile/Favorite-Listing") {
             Globals.showBottomBar = true
             ProfileFavoritesScreen(navigateToListing = { id: String -> navController.navigate("Listing/$id") })
+        }
+
+        composable(route = "Profile/Own-Listings") {
+            Globals.showBottomBar = false
+            ProfileOwnListingsScreen(
+                navigateToProfile = { navController.navigate("Profile") },
+                navigateToListing = { id: String -> navController.navigate("DetailedListing/$id") }
+            )
         }
 
         composable(route = "EditProfile") {

--- a/app/src/main/java/com/studhub/app/NavigationComponent.kt
+++ b/app/src/main/java/com/studhub/app/NavigationComponent.kt
@@ -56,14 +56,14 @@ fun AppNavigation(
 
         composable(route = "Auth/VerifyEmail") {
             Globals.showBottomBar = false
-            VerifyEmailScreen(navigateToProfileScreen = { navController.navigate("EditProfile") })
+            VerifyEmailScreen(navigateToProfileScreen = { navController.navigate("Profile/Edit") })
         }
 
         composable(route = "Profile") {
             Globals.showBottomBar = true
             ProfileScreen(
                 navigateToAuthScreen = { navController.navigate("Auth") },
-                navigateToEditProfileScreen = { navController.navigate("EditProfile") },
+                navigateToEditProfileScreen = { navController.navigate("Profile/Edit") },
                 navigateToProfileFavorites = { navController.navigate("Profile/Favorite-Listing") }
             )
         }
@@ -77,11 +77,11 @@ fun AppNavigation(
             Globals.showBottomBar = false
             ProfileOwnListingsScreen(
                 navigateToProfile = { navController.navigate("Profile") },
-                navigateToListing = { id: String -> navController.navigate("DetailedListing/$id") }
+                navigateToListing = { id: String -> navController.navigate("Listing/$id") }
             )
         }
 
-        composable(route = "EditProfile") {
+        composable(route = "Profile/Edit") {
             Globals.showBottomBar = false
             EditProfileScreen(navigateToProfile = { navController.navigate("Profile") })
         }
@@ -89,24 +89,41 @@ fun AppNavigation(
         composable("Home") {
             Globals.showBottomBar = true
             HomeScreen(
-                onAddListingClick = { navController.navigate("AddListing") },
+                onAddListingClick = { navController.navigate("Listing/Add") },
                 onConversationClick = { navController.navigate("Conversations") },
-                onBrowseClick = { navController.navigate("Browse") },
+                onBrowseClick = { navController.navigate("Listing") },
                 onAboutClick = { navController.navigate("About") },
                 onCartClick = { navController.navigate("Cart") },
                 onProfileClick = { navController.navigate("Profile")
                 }
             )
         }
-        composable("AddListing") {
-            Globals.showBottomBar = false
-            CreateListingScreen(
-                navigateToListing = { id: String -> navController.navigate("DetailedListing/$id") },
-                navigateBack = { navController.popBackStack() })
-        }
-        composable("Browse") {
+
+        composable("Listing") {
             Globals.showBottomBar = true
             BrowseScreen(navController = navController)
+        }
+
+        composable("Listing/{id}") { backStackEntry ->
+            Globals.showBottomBar = false
+            val id = backStackEntry.arguments?.getString("id")
+            if (id == null) {
+                navController.navigate("Listing")
+                return@composable
+            }
+
+            DetailedListingScreen(
+                id = id,
+                navigateToConversation = { conversationId -> navController.navigate("Conversations/$conversationId") },
+                navigateToRateUser = { userId -> navController.navigate("RatingScreen/$userId") }
+            )
+        }
+
+        composable("Listing/Add") {
+            Globals.showBottomBar = false
+            CreateListingScreen(
+                navigateToListing = { id: String -> navController.navigate("Listing/$id") },
+                navigateBack = { navController.popBackStack() })
         }
 
         composable("About") {
@@ -127,21 +144,6 @@ fun AppNavigation(
             }
 
             ChatScreen(conversationId = id, navigateBack = { navController.popBackStack() })
-        }
-
-        composable("DetailedListing/{id}") { backStackEntry ->
-            Globals.showBottomBar = false
-            val id = backStackEntry.arguments?.getString("id")
-            if (id == null) {
-                navController.navigate("Browse")
-                return@composable
-            }
-
-            DetailedListingScreen(
-                id = id,
-                navigateToConversation = { conversationId -> navController.navigate("Conversations/$conversationId") },
-                navigateToRateUser = { userId -> navController.navigate("RatingScreen/$userId") }
-            )
         }
 
 //        composable("RatingScreen") {

--- a/app/src/main/java/com/studhub/app/NavigationComponent.kt
+++ b/app/src/main/java/com/studhub/app/NavigationComponent.kt
@@ -43,7 +43,6 @@ fun AppNavigation(
             )
         }
 
-
         composable(route = "Auth/SignUp") {
             Globals.showBottomBar = false
             SignUpScreen(navigateBack = { navController.navigate("Auth") })
@@ -64,7 +63,8 @@ fun AppNavigation(
             ProfileScreen(
                 navigateToAuthScreen = { navController.navigate("Auth") },
                 navigateToEditProfileScreen = { navController.navigate("Profile/Edit") },
-                navigateToProfileFavorites = { navController.navigate("Profile/Favorite-Listing") }
+                navigateToProfileFavorites = { navController.navigate("Profile/Favorite-Listing") },
+                navigateToOwnListings = { navController.navigate("Profile/Own-Listings") }
             )
         }
 

--- a/app/src/main/java/com/studhub/app/data/repository/ListingRepositoryImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/repository/ListingRepositoryImpl.kt
@@ -133,7 +133,7 @@ class ListingRepositoryImpl @Inject constructor(
 
             query.result.children.forEach { snapshot ->
                 val listing = snapshot.getValue(Listing::class.java)
-                if (listing != null && listing.sellerId == user.id) {
+                if (listing != null && (listing.sellerId == user.id || listing.seller.id == user.id)) {
                     listings.add(listing)
                 }
             }

--- a/app/src/main/java/com/studhub/app/data/repository/ListingRepositoryImpl.kt
+++ b/app/src/main/java/com/studhub/app/data/repository/ListingRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.studhub.app.data.repository
 
+import android.util.Log
 import com.google.firebase.database.FirebaseDatabase
 import com.studhub.app.core.utils.ApiResponse
 import com.studhub.app.data.local.LocalDataSource
@@ -7,6 +8,7 @@ import com.studhub.app.data.network.NetworkStatus
 import com.studhub.app.data.storage.StorageHelper
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.ListingType
+import com.studhub.app.domain.model.User
 import com.studhub.app.domain.repository.ListingRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -111,6 +113,36 @@ class ListingRepositoryImpl @Inject constructor(
         } else {
             val errorMessage = query.exception?.message.orEmpty()
             emit(ApiResponse.Failure(errorMessage.ifEmpty { "Firebase error" }))
+        }
+    }
+
+    override suspend fun getUserListings(user: User): Flow<ApiResponse<List<Listing>>> = flow {
+        emit(ApiResponse.Loading)
+
+        if (!networkStatus.isConnected) {
+            emit(ApiResponse.NO_INTERNET_CONNECTION)
+            return@flow
+        }
+
+        val query = db.get()
+
+        query.await()
+
+        if (query.isSuccessful) {
+            val listings = mutableListOf<Listing>()
+
+            query.result.children.forEach { snapshot ->
+                val listing = snapshot.getValue(Listing::class.java)
+                if (listing != null && listing.sellerId == user.id) {
+                    listings.add(listing)
+                }
+            }
+
+            emit(ApiResponse.Success(listings))
+        } else {
+            val errorMessage = query.exception?.message.orEmpty()
+            Log.w("LISTING_REPO", errorMessage)
+            emit(ApiResponse.Failure("Database Error"))
         }
     }
 

--- a/app/src/main/java/com/studhub/app/domain/repository/ListingRepository.kt
+++ b/app/src/main/java/com/studhub/app/domain/repository/ListingRepository.kt
@@ -2,44 +2,52 @@ package com.studhub.app.domain.repository
 
 import com.studhub.app.core.utils.ApiResponse
 import com.studhub.app.domain.model.Listing
+import com.studhub.app.domain.model.User
 import kotlinx.coroutines.flow.Flow
 import java.util.*
 
 interface ListingRepository {
     /**
-     * create a [listing] on the database of Firebase
-     * @param [listing] the listing we want to create
+     * Create a [Listing] in the repository
+     * @param listing the listing we want to create
      * @return A [Flow] of [ApiResponse] with the last one containing the [Listing] pushed to the database on success
      */
     suspend fun createListing(listing: Listing): Flow<ApiResponse<Listing>>
 
     /**
-     * get a list of [listing] with all the listings on the database of Firebase
-     * @return A [Flow] of [ApiResponse] with the last one containing the list of [Listing] pushed to the database on success
+     * Get a [List] of all the [Listing] in the repository
+     * @return A [Flow] of [ApiResponse] with the last one containing the list of [Listing] retrieved from the repository on success
      */
     suspend fun getListings(): Flow<ApiResponse<List<Listing>>>
 
     /**
-     * get a  [listing] with all the listings on the database of Firebase
-     * @param [listingId] the listingId we want to match
-     * @return A [Flow] of [ApiResponse] with the last one containing the [Listing] pushed to the database on success
+     * Get the [Listing] with the given [listingId] from the repository
+     * @param [listingId] the ID of the listing we want to match
+     * @return A [Flow] of [ApiResponse] with the last one containing the [Listing] retrieved from the repository on success
      */
     suspend fun getListing(listingId: String): Flow<ApiResponse<Listing>>
 
     /**
-     * get a list of [listing] with all the listings on the database of Firebase with the constraint given on parameter
+     * Get the [List] of [Listing] created by the given [user]
+     * @return A [Flow] of [ApiResponse] with the last one containing the list of [Listing] retrieved from the repository on success
+     */
+    suspend fun getUserListings(user: User): Flow<ApiResponse<List<Listing>>>
+
+    /**
+     * Get a [List] of [Listing] with all the listings on the database of Firebase with the constraint given on parameter
      * @param [keyword] the constraint we want the listings to filter
      * @param [blockedUsers] the list of users that we don't want to see their listings
      * @return A [Flow] of [ApiResponse] with the last one containing the filtered list of [Listing] pushed to the database on success
      */
-    suspend fun getListingsBySearch(keyword: String,
-                                    minPrice: String,
-                                    maxPrice: String,
-                                    blockedUsers: Map<String, Boolean>
-                                    ): Flow<ApiResponse<List<Listing>>>
+    suspend fun getListingsBySearch(
+        keyword: String,
+        minPrice: String,
+        maxPrice: String,
+        blockedUsers: Map<String, Boolean>
+    ): Flow<ApiResponse<List<Listing>>>
 
     /**
-     * update a listing with the given [listingId]
+     * Updates the [Listing] with the given [listingId]
      * @param [listingId] the listingId we want to match
      * @param [updatedListing] the Listing we want to replace
      * @return A [Flow] of [ApiResponse] with the last one containing the updated [Listing] pushed to the database on success
@@ -63,5 +71,9 @@ interface ListingRepository {
      * @param [deadline] the deadline for the fixing the bidding price
      * @return A [Flow] of [ApiResponse] with the last one containing the updated [Listing] pushed to the database on success
      */
-    suspend fun updateListingToBidding(listing: Listing, startingPrice: Float, deadline: Date): Flow<ApiResponse<Listing>>
+    suspend fun updateListingToBidding(
+        listing: Listing,
+        startingPrice: Float,
+        deadline: Date
+    ): Flow<ApiResponse<Listing>>
 }

--- a/app/src/main/java/com/studhub/app/domain/usecase/listing/GetOwnListings.kt
+++ b/app/src/main/java/com/studhub/app/domain/usecase/listing/GetOwnListings.kt
@@ -1,0 +1,23 @@
+package com.studhub.app.domain.usecase.listing
+
+import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.domain.model.Listing
+import com.studhub.app.domain.model.User
+import com.studhub.app.domain.repository.AuthRepository
+import com.studhub.app.domain.repository.ListingRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * Use case for retrieving all listings from the logged-in user, from a given [repository]
+ *
+ * @param [repository] the which the use case will act on
+ */
+class GetOwnListings @Inject constructor(
+    private val repository: ListingRepository,
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(): Flow<ApiResponse<List<Listing>>> {
+        return repository.getUserListings(User(id = authRepository.currentUserUid))
+    }
+}

--- a/app/src/main/java/com/studhub/app/presentation/listing/browse/ListingThumbnailScreen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/listing/browse/ListingThumbnailScreen.kt
@@ -2,43 +2,23 @@ package com.studhub.app.presentation.listing.browse
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import com.studhub.app.annotations.ExcludeFromGeneratedTestCoverage
 import com.studhub.app.domain.model.Category
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.ListingType
 import com.studhub.app.domain.model.User
-import com.studhub.app.presentation.ui.browse.ListingContent
+import com.studhub.app.presentation.ui.browse.ListingCard
 import com.studhub.app.presentation.ui.theme.StudHubTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListingThumbnailScreen(
     viewModel: ListingThumbnailViewModel,
     onClick: () -> Unit,
 ) {
-    Card(
-        onClick = onClick,
-        modifier = Modifier
-            .fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer
-        )
-    ) {
-        ListingContent(listing = viewModel.listing, onClick = onClick)
-    }
+    ListingCard(listing = viewModel.listing, onClick = onClick)
 }
 
 @ExcludeFromGeneratedTestCoverage
@@ -51,7 +31,6 @@ fun ListingThumbnailPreview() {
         categories = listOf(Category(name = "Mobility")),
         price = 1560.45F
     )
-
     val listing2 = Listing(
         name = "Limited edition manga",
         seller = User(firstName = "Jimmy", lastName = "Poppin"),
@@ -60,12 +39,10 @@ fun ListingThumbnailPreview() {
         price = 80F
     )
 
-    val viewModel = ListingThumbnailViewModel(listing)
-    val viewModel2 = ListingThumbnailViewModel(listing2)
-    StudHubTheme() {
+    StudHubTheme {
         Column {
-            ListingThumbnailScreen(viewModel = viewModel, onClick = {})
-            ListingThumbnailScreen(viewModel = viewModel2, onClick = {})
+            ListingCard(listing = listing, onClick = {})
+            ListingCard(listing = listing2, onClick = {})
         }
     }
 }

--- a/app/src/main/java/com/studhub/app/presentation/listing/browse/components/BrowseContent.kt
+++ b/app/src/main/java/com/studhub/app/presentation/listing/browse/components/BrowseContent.kt
@@ -29,7 +29,7 @@ fun BrowseContent(listings: List<Listing>, navController: NavController) {
                 ListingThumbnailScreen(
                     viewModel = ListingThumbnailViewModel(listing = listing),
                     onClick = {
-                        navController.navigate("DetailedListing/${listing.id}")
+                        navController.navigate("Listing/${listing.id}")
                     }
                 )
 

--- a/app/src/main/java/com/studhub/app/presentation/listing/browse/components/ListingCard.kt
+++ b/app/src/main/java/com/studhub/app/presentation/listing/browse/components/ListingCard.kt
@@ -4,6 +4,9 @@ package com.studhub.app.presentation.ui.browse
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,9 +22,18 @@ import com.studhub.app.presentation.listing.browse.components.PriceChip
 import com.studhub.app.presentation.listing.browse.components.ThumbnailImage
 
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ListingContent(listing: Listing, onClick: () -> Unit) {
-    Row(
+fun ListingCard(listing: Listing, onClick: () -> Unit) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer
+        )
+    ) {Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(90.dp)
@@ -61,4 +73,6 @@ fun ListingContent(listing: Listing, onClick: () -> Unit) {
             )
         }
     }
+    }
+
 }

--- a/app/src/main/java/com/studhub/app/presentation/nav/NavBar.kt
+++ b/app/src/main/java/com/studhub/app/presentation/nav/NavBar.kt
@@ -25,8 +25,8 @@ fun NavBar(navController: NavHostController = rememberNavController()) {
     //each route will be used for a navbar button
     val items = listOf(
         Route(stringResource(R.string.nav_home_button), "Home", Icons.Filled.Home),
-        Route(stringResource(R.string.nav_browse_button), "Browse", Icons.Filled.Search),
-        Route(stringResource(R.string.nav_sell_button), "AddListing", Icons.Filled.AddCircle),
+        Route(stringResource(R.string.nav_browse_button), "Listing", Icons.Filled.Search),
+        Route(stringResource(R.string.nav_sell_button), "Listing/Add", Icons.Filled.AddCircle),
         Route(stringResource(R.string.nav_chat_button), "Conversations", Icons.Filled.MailOutline),
         Route(stringResource(R.string.nav_profile_button), "Profile", Icons.Filled.AccountBox)
     )

--- a/app/src/main/java/com/studhub/app/presentation/profile/ProfileOwnListingsScreen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/profile/ProfileOwnListingsScreen.kt
@@ -17,14 +17,12 @@ fun ProfileOwnListingsScreen(
         viewModel.getOwnListings()
     }
 
-    when (val ownListings = viewModel.ownListings) {
-        is ApiResponse.Loading -> LoadingCircle()
-        is ApiResponse.Failure -> {}
-        is ApiResponse.Success ->
-            ProfileOwnListingsContent(
-                listings = ownListings.data,
-                navigateToProfile = navigateToProfile,
-                navigateToListing = navigateToListing
-            )
-    }
+    val isLoading = viewModel.ownListings !is ApiResponse.Success
+
+    ProfileOwnListingsContent(
+        listings = if (isLoading) emptyList() else (viewModel.ownListings as ApiResponse.Success).data,
+        navigateToProfile = navigateToProfile,
+        navigateToListing = navigateToListing,
+        isLoading = isLoading
+    )
 }

--- a/app/src/main/java/com/studhub/app/presentation/profile/ProfileOwnListingsScreen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/profile/ProfileOwnListingsScreen.kt
@@ -1,0 +1,30 @@
+package com.studhub.app.presentation.profile
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.studhub.app.core.utils.ApiResponse
+import com.studhub.app.presentation.profile.components.ProfileOwnListingsContent
+import com.studhub.app.presentation.ui.common.misc.LoadingCircle
+
+@Composable
+fun ProfileOwnListingsScreen(
+    viewModel: ProfileViewModel = hiltViewModel(),
+    navigateToProfile: () -> Unit,
+    navigateToListing: (id: String) -> Unit
+) {
+    LaunchedEffect(Unit) {
+        viewModel.getOwnListings()
+    }
+
+    when (val ownListings = viewModel.ownListings) {
+        is ApiResponse.Loading -> LoadingCircle()
+        is ApiResponse.Failure -> {}
+        is ApiResponse.Success ->
+            ProfileOwnListingsContent(
+                listings = ownListings.data,
+                navigateToProfile = navigateToProfile,
+                navigateToListing = navigateToListing
+            )
+    }
+}

--- a/app/src/main/java/com/studhub/app/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/profile/ProfileScreen.kt
@@ -15,7 +15,8 @@ fun ProfileScreen(
     viewModel: ProfileViewModel = hiltViewModel(),
     navigateToAuthScreen: () -> Unit,
     navigateToEditProfileScreen: () -> Unit,
-    navigateToProfileFavorites: () -> Unit
+    navigateToProfileFavorites: () -> Unit,
+    navigateToOwnListings: () -> Unit
 ) {
 
     val scaffoldState = rememberScaffoldState()
@@ -37,7 +38,8 @@ fun ProfileScreen(
                     ProfileContent(
                         padding = padding,
                         profile = currentUser.data,
-                        navigateToProfileFavorites = navigateToProfileFavorites
+                        navigateToProfileFavorites = navigateToProfileFavorites,
+                        navigateToOwnListings = navigateToOwnListings
                     )
                 },
                 scaffoldState = scaffoldState

--- a/app/src/main/java/com/studhub/app/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/studhub/app/presentation/profile/ProfileViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.studhub.app.core.utils.ApiResponse
 import com.studhub.app.domain.model.Listing
 import com.studhub.app.domain.model.User
+import com.studhub.app.domain.usecase.listing.GetOwnListings
 import com.studhub.app.domain.usecase.user.GetCurrentUser
 import com.studhub.app.domain.usecase.user.GetFavoriteListings
 import com.studhub.app.domain.usecase.user.SignOut
@@ -22,12 +23,16 @@ class ProfileViewModel @Inject constructor(
     private val _signOut: SignOut,
     private val getCurrentUser: GetCurrentUser,
     private val updateCurrentUserInfo: UpdateCurrentUserInfo,
-    private val getFavoriteListings: GetFavoriteListings
+    private val getFavoriteListings: GetFavoriteListings,
+    private val _getOwnListings: GetOwnListings
 ) : ViewModel() {
     var signOutResponse by mutableStateOf<ApiResponse<Boolean>>(ApiResponse.Loading)
         private set
 
     var currentUser by mutableStateOf<ApiResponse<User>>(ApiResponse.Loading)
+        private set
+
+    var ownListings by mutableStateOf<ApiResponse<List<Listing>>>(ApiResponse.Loading)
         private set
 
     private val _userFavorites = MutableSharedFlow<List<Listing>>(replay = 0)
@@ -41,6 +46,13 @@ class ProfileViewModel @Inject constructor(
         viewModelScope.launch {
             getCurrentUser().collect {
                 currentUser = it
+            }
+        }
+
+    fun getOwnListings() =
+        viewModelScope.launch {
+            _getOwnListings().collect {
+                ownListings = it
             }
         }
 

--- a/app/src/main/java/com/studhub/app/presentation/profile/components/ProfileContent.kt
+++ b/app/src/main/java/com/studhub/app/presentation/profile/components/ProfileContent.kt
@@ -1,7 +1,10 @@
 package com.studhub.app.presentation.profile.components
 
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -9,24 +12,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.studhub.app.R
 import com.studhub.app.domain.model.User
 import com.studhub.app.presentation.ui.common.button.BasicFilledButton
 import com.studhub.app.presentation.ui.common.misc.Avatar
+import com.studhub.app.presentation.ui.common.misc.Spacer
 import com.studhub.app.presentation.ui.common.text.BigLabel
 
 @Composable
 fun ProfileContent(
     padding: PaddingValues,
     profile: User,
-    navigateToProfileFavorites: () -> Unit
+    navigateToProfileFavorites: () -> Unit,
+    navigateToOwnListings: () -> Unit
 ) {
     val scrollState = rememberScrollState()
     Surface(
         modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background)
-    {
+        color = MaterialTheme.colorScheme.background
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -34,7 +38,7 @@ fun ProfileContent(
                 .horizontalScroll(scrollState),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(modifier = Modifier.height(48.dp))
+            Spacer("big")
 
             Avatar(picture = profile.profilePicture.ifEmpty { null })
 
@@ -43,6 +47,13 @@ fun ProfileContent(
             BasicFilledButton(
                 onClick = { navigateToProfileFavorites() },
                 label = stringResource(R.string.profile_btn_display_favs)
+            )
+
+            Spacer()
+
+            BasicFilledButton(
+                onClick = { navigateToOwnListings() },
+                label = stringResource(R.string.profile_btn_display_own_listings)
             )
         }
     }

--- a/app/src/main/java/com/studhub/app/presentation/profile/components/ProfileOwnListingsContent.kt
+++ b/app/src/main/java/com/studhub/app/presentation/profile/components/ProfileOwnListingsContent.kt
@@ -1,7 +1,5 @@
 package com.studhub.app.presentation.profile.components
 
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,22 +23,19 @@ fun ProfileOwnListingsContent(
         if (listings.isEmpty()) {
             Text(text = stringResource(id = R.string.profile_own_listings_no_listings))
         } else {
-            LazyColumn {
-                items(listings) { listing ->
-                    Spacer("small")
+            listings.map {
+                Spacer("small")
 
-                    ListingCard(
-                        listing,
-                        onClick = {
-                            navigateToListing(listing.id)
-                        }
-                    )
+                ListingCard(
+                    listing = it,
+                    onClick = {
+                        navigateToListing(it.id)
+                    }
+                )
 
-                    Spacer("small")
-                    Divider()
-                }
+                Spacer("small")
+                Divider()
             }
         }
     }
-
 }

--- a/app/src/main/java/com/studhub/app/presentation/profile/components/ProfileOwnListingsContent.kt
+++ b/app/src/main/java/com/studhub/app/presentation/profile/components/ProfileOwnListingsContent.kt
@@ -1,0 +1,46 @@
+package com.studhub.app.presentation.profile.components
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.studhub.app.R
+import com.studhub.app.domain.model.Listing
+import com.studhub.app.presentation.ui.browse.ListingCard
+import com.studhub.app.presentation.ui.common.container.Screen
+import com.studhub.app.presentation.ui.common.misc.Spacer
+
+@Composable
+fun ProfileOwnListingsContent(
+    listings: List<Listing>,
+    navigateToProfile: () -> Unit,
+    navigateToListing: (id: String) -> Unit
+) {
+    Screen(
+        title = stringResource(id = R.string.profile_own_listings_title),
+        onGoBackClick = navigateToProfile
+    ) {
+        if (listings.isEmpty()) {
+            Text(text = stringResource(id = R.string.profile_own_listings_no_listings))
+        } else {
+            LazyColumn {
+                items(listings) { listing ->
+                    Spacer("small")
+
+                    ListingCard(
+                        listing,
+                        onClick = {
+                            navigateToListing(listing.id)
+                        }
+                    )
+
+                    Spacer("small")
+                    Divider()
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/studhub/app/presentation/profile/components/ProfileOwnListingsContent.kt
+++ b/app/src/main/java/com/studhub/app/presentation/profile/components/ProfileOwnListingsContent.kt
@@ -14,11 +14,13 @@ import com.studhub.app.presentation.ui.common.misc.Spacer
 fun ProfileOwnListingsContent(
     listings: List<Listing>,
     navigateToProfile: () -> Unit,
-    navigateToListing: (id: String) -> Unit
+    navigateToListing: (id: String) -> Unit,
+    isLoading: Boolean
 ) {
     Screen(
         title = stringResource(id = R.string.profile_own_listings_title),
-        onGoBackClick = navigateToProfile
+        onGoBackClick = navigateToProfile,
+        isLoading = isLoading
     ) {
         if (listings.isEmpty()) {
             Text(text = stringResource(id = R.string.profile_own_listings_no_listings))

--- a/app/src/main/java/com/studhub/app/presentation/ui/common/container/Screen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/ui/common/container/Screen.kt
@@ -11,12 +11,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.studhub.app.R
+import com.studhub.app.presentation.ui.common.misc.LoadingCircle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Screen(
     title: String,
     onGoBackClick: (() -> Unit)?,
+    isLoading: Boolean = false,
     content: @Composable ColumnScope.() -> Unit
 ) {
     val scrollState = rememberScrollState()
@@ -28,7 +30,7 @@ fun Screen(
                     title = { Text(text = title) },
                     navigationIcon = {
                         IconButton(
-                            onClick = onGoBackClick
+                            onClick = onGoBackClick,
                         ) {
                             Icon(
                                 imageVector = Icons.Outlined.ArrowBack,
@@ -37,17 +39,20 @@ fun Screen(
                         }
                     }
                 )
-            else TopAppBar( title = { Text(text = title) } )
+            else TopAppBar(title = { Text(text = title) })
         },
         content = {
-            Column(
-                modifier = Modifier
-                    .padding(it)
-                    .verticalScroll(scrollState)
-                    .fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                content = content
-            )
+            if (isLoading)
+                LoadingCircle()
+            else
+                Column(
+                    modifier = Modifier
+                        .padding(it)
+                        .verticalScroll(scrollState)
+                        .fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    content = content
+                )
         }
     )
 }

--- a/app/src/main/java/com/studhub/app/presentation/ui/common/container/Screen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/ui/common/container/Screen.kt
@@ -17,7 +17,7 @@ import com.studhub.app.presentation.ui.common.misc.LoadingCircle
 @Composable
 fun Screen(
     title: String,
-    onGoBackClick: (() -> Unit)?,
+    onGoBackClick: (() -> Unit)? = null,
     isLoading: Boolean = false,
     content: @Composable ColumnScope.() -> Unit
 ) {

--- a/app/src/main/java/com/studhub/app/presentation/ui/common/container/Screen.kt
+++ b/app/src/main/java/com/studhub/app/presentation/ui/common/container/Screen.kt
@@ -1,0 +1,53 @@
+package com.studhub.app.presentation.ui.common.container
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.studhub.app.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun Screen(
+    title: String,
+    onGoBackClick: (() -> Unit)?,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        topBar = {
+            if (onGoBackClick != null)
+                TopAppBar(
+                    title = { Text(text = title) },
+                    navigationIcon = {
+                        IconButton(
+                            onClick = onGoBackClick
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.ArrowBack,
+                                contentDescription = stringResource(R.string.misc_btn_go_back),
+                            )
+                        }
+                    }
+                )
+            else TopAppBar( title = { Text(text = title) } )
+        },
+        content = {
+            Column(
+                modifier = Modifier
+                    .padding(it)
+                    .verticalScroll(scrollState)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                content = content
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/studhub/app/wrapper/ProfileActivity.kt
+++ b/app/src/main/java/com/studhub/app/wrapper/ProfileActivity.kt
@@ -15,7 +15,9 @@ class ProfileActivity : AppCompatActivity() {
             ProfileScreen(
                 navigateToAuthScreen = {},
                 navigateToEditProfileScreen = {},
-                navigateToProfileFavorites = {})
+                navigateToProfileFavorites = {},
+                navigateToOwnListings = {}
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings_profile.xml
+++ b/app/src/main/res/values/strings_profile.xml
@@ -7,6 +7,8 @@
     <string name="profile_edit_title">Edit profile information</string>
     <string name="profile_favorites_title">Favorite Listings</string>
     <string name="profile_favorites_no_favs">No favorite items yet</string>
+    <string name="profile_own_listings_title">Your Listings</string>
+    <string name="profile_own_listings_no_listings">You have not created any listings yet.</string>
     <string name="profile_edit_form_label_firstname">First Name</string>
     <string name="profile_edit_form_label_lastname">Last Name</string>
     <string name="profile_edit_form_label_username">User Name</string>

--- a/app/src/main/res/values/strings_profile.xml
+++ b/app/src/main/res/values/strings_profile.xml
@@ -4,6 +4,7 @@
     <string name="profile_btn_sign_out">Sign out</string>
     <string name="profile_btn_edit_profile">Edit</string>
     <string name="profile_btn_display_favs">Display favorite listings</string>
+    <string name="profile_btn_display_own_listings">Display your listings</string>
     <string name="profile_edit_title">Edit profile information</string>
     <string name="profile_favorites_title">Favorite Listings</string>
     <string name="profile_favorites_no_favs">No favorite items yet</string>


### PR DESCRIPTION
This PR adds the "Own Listings" screen, accessible from the profile page which allows users to have direct access to all the listings they created.
A use-case (`GetOwnListings`) and its corresponding repository methods have also been added.

A new `Screen` composable has also been added. This composable displays a top banner and a scrollable content which is hidden by a circular loader when the `isLoading` parameter is set to true.

Last but ~not~ least, route names have been refactored in the navigation graph (`NavigationComponent.kt`)